### PR TITLE
fix(build): shellcheck exclude **/bazel-*

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -17,6 +17,7 @@
 # https://github.com/aignas/rules_shellcheck
 load("@com_github_aignas_rules_shellcheck//:def.bzl", "shellcheck_test")
 
+# TODO https://github.com/aignas/rules_shellcheck/issues/17 this does not work reliably... :-(
 shellcheck_test(
     name = "shellcheck_test",
     size = "small",
@@ -26,8 +27,8 @@ shellcheck_test(
             "**/*.sh",
         ],
         exclude = [
-            "bazel-bin/**",
-            "bazel-out/**",
+            "**/bazel-bin/**",
+            "**/bazel-out/**",
             "site/**",
             ".venv/**",
         ],


### PR DESCRIPTION
This seems to help at least partially for https://github.com/aignas/rules_shellcheck/issues/17.