### PR TITLE
fix (build): Bump rules_jvm_external from 4.5 to 5.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # https://github.com/bazelbuild/rules_jvm_external/blob/master/docs/bzlmod.md#installation
-bazel_dep(name = "rules_jvm_external", version = "4.5")
+bazel_dep(name = "rules_jvm_external", version = "5.1")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(


### PR DESCRIPTION
This does *NOT* fix https://github.com/bazelbuild/rules_jvm_external/issues/872, but it's probably still a good idea to upgrade anyway.