### PR TITLE
Fix ./enola CLI script so that it can run from anywhere

### DIFF
--- a/enola
+++ b/enola
@@ -20,4 +20,4 @@ set -euo pipefail
 bazelisk build //cli/...
 echo
 echo
-./bazel-bin/cli/enola "$@"
+"$(realpath "$(dirname "$0")")"/bazel-bin/cli/enola "$@"


### PR DESCRIPTION
This makes it work even if the current working directory is not the project root. This is handy e.g. when invoking it on models files that are stored outside of this project.