### PR TITLE
fix: Disable DeepSource Google Java Format

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -8,6 +8,3 @@ name = "java"
 
 [[analyzers]]
 name = "shell"
-
-[[transformers]]
-name = "google-java-format"


### PR DESCRIPTION
#95 is wrong - it doesn't take `--aosp` (for 4 instead of 2 spaces) into account.

As https://pre-commit.ci already does this as well, let's not have DeepSource also do this.