### PR TITLE
EntityRelationship Template support

### DIFF
--- a/core/impl/src/test/java/dev/enola/core/EntityServiceProviderTest.java
+++ b/core/impl/src/test/java/dev/enola/core/EntityServiceProviderTest.java
@@ -58,15 +58,18 @@ public class EntityServiceProviderTest {
 
     @Test
     public void testUriTemplate() throws ValidationException, EnolaException, IOException {
-        var template = "https://www.google.com/search?q={path.name}+dog&sclient=img";
         var kid = ID.newBuilder().setNs("test").setEntity("dog").addPaths("name").build();
+        var template = "https://www.google.com/search?q={path.name}+dog&sclient=img";
         var href = Link.newBuilder().setUriTemplate(template).build();
-        var rel1 = EntityRelationship.newBuilder().setLabel("test").build();
+        var rel1 = EntityRelationship.newBuilder().build();
+        var tid = ID.newBuilder().setNs("test").setEntity("cat").addPaths("{path.name}").build();
+        var rel2 = EntityRelationship.newBuilder().setId(tid).build();
         var kind =
                 EntityKind.newBuilder()
                         .setId(kid)
                         .putLink("image", href)
                         .putRelated("rel1", rel1)
+                        .putRelated("rel2", rel2)
                         .build();
         var ekr = new EntityKindRepository().put(kind);
         var service = new EnolaServiceProvider().get(ekr);
@@ -87,6 +90,10 @@ public class EntityServiceProviderTest {
                 .isEqualTo("https://www.google.com/search?q=king-charles+dog&sclient=img");
 
         assertThat(entity.getRelatedOrThrow("rel1").getEntity()).isEqualTo("cat");
+
+        assertThat(entity.getRelatedOrThrow("rel2").getNs()).isEqualTo("test");
+        assertThat(entity.getRelatedOrThrow("rel2").getEntity()).isEqualTo("cat");
+        assertThat(entity.getRelatedOrThrow("rel2").getPathsList()).containsExactly("king-charles");
     }
 
     @Test

--- a/core/lib/src/main/java/dev/enola/core/enola_core.proto
+++ b/core/lib/src/main/java/dev/enola/core/enola_core.proto
@@ -55,9 +55,8 @@ message ID {
   // (This restriction could in theory be relaxed, if there was a strong need
   // to support it; as long as sufficient test coverage is added for correct
   // encoding in URIs, see https://en.m.wikipedia.org/wiki/URL_encoding.)
-  // Multiple "segments" are supports for "composed keys", for example a
-  // network/context/namespace/name kind of format.
-  // TODO If needed, maybe (later) oneof map<string, string> for multi??
+  // Multiple "segments" are supported for "composed keys", for example a
+  // network/context/namespace/name kind of ID.
   repeated string paths = 3;
 }
 

--- a/core/lib/src/main/java/dev/enola/core/meta/enola_meta.proto
+++ b/core/lib/src/main/java/dev/enola/core/meta/enola_meta.proto
@@ -88,7 +88,9 @@ message EntityRelationship {
   string description = 3;
 
   // ID reference to another Entity.
-  // Path is empty and set per Entity by connector service implementations.
+  // This ID's ns/entity/paths fields can contain a template, like
+  // Link#uri_template. Alternatively, this can be left empty, and set by
+  // connectors.
   ID id = 4;
 
   // Tags.

--- a/docs/use/library/model.textproto
+++ b/docs/use/library/model.textproto
@@ -27,12 +27,10 @@ kinds {
   emoji: "📖"
   related {
     key: "library",
-    value: { id: { ns: "demo" entity: "library" } }
-    # TODO uri_template: "enola:demo.library/{path.library}"
+    value: { id: { ns: "demo" entity: "library" paths: "{path.library}" } }
   }
   related {
     key: "kind",
-    value: { id: { ns: "demo" entity: "book_kind" } }
-    # TODO uri_template: "enola:demo.book_kind/{path.isbn}"
+    value: { id: { ns: "demo" entity: "book_kind" paths: "{path.isbn}" } }
   }
 }

--- a/web/api/src/main/java/dev/enola/web/WebServer.java
+++ b/web/api/src/main/java/dev/enola/web/WebServer.java
@@ -24,7 +24,7 @@ import java.net.InetSocketAddress;
  * this API could be based on e.g. the <tt>com.sun.net.httpserver.HttpServer</tt>, or <i>Netty</i>,
  * or <i>Jetty</i> or <i>Tomcat</i> or <i>Vert.x</i> - or any other similar such HTTP framework.
  * Please note that there may well also be non-open source implementations which map this API to
- * some proprietary in-house web frameworks.
+ * some proprietary in-house Web Application Frameworks.
  */
 public interface WebServer extends AutoCloseable {
 

--- a/web/ui/src/main/resources/ui.soy
+++ b/web/ui/src/main/resources/ui.soy
@@ -25,6 +25,11 @@ import {Entity} from 'core/lib/src/main/java/dev/enola/core/enola_core.proto';
     {$id.ns}.{$id.entity}{for $element in $id.pathsList}/{$element}{/for}
 {/template}
 
+{template idHref kind="uri"}
+    {@param id: ID}
+    /ui/entity/{$id.ns}.{$id.entity}{for $element in $id.pathsList}/{$element}{/for}
+{/template}
+
 {template entity}
     {@param e: Entity}
 
@@ -40,7 +45,8 @@ import {Entity} from 'core/lib/src/main/java/dev/enola/core/enola_core.proto';
     <!-- TODO Only if $e.relatedMap.size() > 0 ... -->
     <h2>Related</h2>
     <ul>{for $related in $e.relatedMap.entries()}
-        <li><a href="/ui/entity/{$related.value}">{$related.key}</a></li>
+        <!-- The follow format (roughly) matches dev.enola.core.IDs#toPath -->
+        <li><a href="{idHref(id: $related.value)}">{$related.key}</a></li>
     {/for}</ul>
 
     <!-- TODO Only if $e.linkMap.size() > 0 ... -->


### PR DESCRIPTION
Relates (indirectly) to #76

@gabrielh the `ID` in `related` can now use templates (RFC 6570) - just like the `Link#uri_template`.

The `library/model.textproto` change in this PR best illustrates how this is used.