### PR TITLE
fix (build): Use GitHub /releases/ instead of /archive/ URL for rules_proto_grpc

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -23,9 +23,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # are done.
 http_archive(
     name = "rules_proto_grpc",
-    sha256 = "b244cbede34638ad0e1aec0769f62b8348c7ed71f431a027e252a07d6adba3d6",
+    sha256 = "928e4205f701b7798ce32f3d2171c1918b363e9a600390a25c876f075f1efc0a",
     strip_prefix = "rules_proto_grpc-4.4.0",
-    urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/4.4.0.tar.gz"],
+    urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/releases/download/4.4.0/rules_proto_grpc-4.4.0.tar.gz"],
 )
 
 load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_repos", "rules_proto_grpc_toolchains")


### PR DESCRIPTION
from https://rules-proto-grpc.com/en/latest/#installation, as per https://github.com/rules-proto-grpc/rules_proto_grpc/releases/tag/4.4.0.
