### PR TITLE
Moved the logic in ui.soy to UI.java via a new proto messages defined in web\view\src\main\java\dev\enola\web\enola_view.proto Added a richer model.textproto in docs/use/library to match new entity augmentation in the connector demo: connectors\demo\src\main\java\dev\enola\demo\DemoConnector.jav

### DIFF
--- a/cli/src/main/java/dev/enola/cli/ServerCommand.java
+++ b/cli/src/main/java/dev/enola/cli/ServerCommand.java
@@ -40,7 +40,7 @@ public class ServerCommand extends CommandWithModel {
     protected void run(EntityKindRepository ekr) throws Exception {
         EnolaService service = new EnolaServiceProvider().get(ekr);
         var server = new SunServer(new InetSocketAddress(port));
-        new UI(service).register(server);
+        new UI(service,ekr).register(server);
         server.start();
         System.out.println("Open http://localhost:" + port + "/ui ...");
         Thread.currentThread().join();

--- a/connectors/demo/BUILD
+++ b/connectors/demo/BUILD
@@ -40,6 +40,7 @@ java_binary(
     # resources = glob(["src/test/resources/**/*"]),
     deps = [
         ":demo",
+        "//core/lib:lib_java",
         "//core/lib:core_java_grpc",
         "//core/lib:core_java_proto",
         "@maven//:com_google_truth_truth",

--- a/connectors/demo/BUILD
+++ b/connectors/demo/BUILD
@@ -24,6 +24,9 @@ java_binary(
     # resources = glob(["src/main/resources/**/*"]),
     deps = [
         "//core/lib:core_java_grpc",
+        "//core/lib:core_java_proto",
+        "//core/lib:lib_java",
+        "@maven//:com_google_protobuf_protobuf_java_util",
     ],
 )
 

--- a/connectors/demo/src/main/java/dev/enola/demo/DemoConnector.java
+++ b/connectors/demo/src/main/java/dev/enola/demo/DemoConnector.java
@@ -21,13 +21,68 @@ import dev.enola.core.connector.proto.AugmentRequest;
 import dev.enola.core.connector.proto.AugmentResponse;
 import dev.enola.core.connector.proto.ConnectorServiceGrpc;
 
+import dev.enola.core.connector.proto.ConnectorServiceGrpc;
+
+import com.google.protobuf.Struct;
+import com.google.protobuf.Any;
+
+import dev.enola.core.IDs;
+import dev.enola.core.proto.ID;
+import dev.enola.core.util.proto.EnolaString;
+
 import io.grpc.stub.StreamObserver;
 
 public class DemoConnector extends ConnectorServiceGrpc.ConnectorServiceImplBase {
     @Override
     public void augment(AugmentRequest request, StreamObserver<AugmentResponse> responseObserver) {
         var entity = request.getEntity().toBuilder();
-        entity.putLink("link1", "http://www.vorburger.ch");
+
+        //dev.enola.core.util
+        var s = Struct.newBuilder();
+        //s.update("k","v");
+
+
+        System.out.println(IDs.toPath(entity.getId()));
+        if (IDs.toPath(entity.getId()).equals("demo.work/8706-1000")) {
+
+            Any any = Any.pack(EnolaString.newBuilder().setValue("En attendant Godot").build());
+            entity.putData("title", any);
+
+            any = Any.pack(EnolaString.newBuilder().setValue("French").build());
+            entity.putData("language", any);
+
+            entity.putLink("wikipedia", "https://en.wikipedia.org/wiki/Waiting_for_Godot");
+            entity.putLink("search", "https://www.google.com/search?q=En%20attendant%20Godot");
+
+            var id  = ID.newBuilder().setNs("demo").setEntity("author").addPaths("samuel_beckett").build();
+            entity.putRelated("author", id);
+        }
+        if (IDs.toPath(entity.getId()).equals("demo.work/0-13-140731-7")) {
+
+            Any any = Any.pack(EnolaString.newBuilder().setValue("Core Java data objects").build());
+            entity.putData("title", any);
+
+            any = Any.pack(EnolaString.newBuilder().setValue("English").build());
+            entity.putData("language", any);
+
+            var id  = ID.newBuilder().setNs("demo").setEntity("author").addPaths("michael_vorburger").build();
+            entity.putRelated("author", id);
+        }
+        if (IDs.toPath(entity.getId()).equals("demo.author/samuel_beckett")) {
+            Any any = Any.pack(EnolaString.newBuilder().setValue("French").build());
+            entity.putData("language", any);
+
+            var id  = ID.newBuilder().setNs("demo").setEntity("work").addPaths("samuel_beckett").build();
+            entity.putRelated("work", id);
+        }
+        if (IDs.toPath(entity.getId()).equals("demo.author/michael_vorburger")) {
+            Any any = Any.pack(EnolaString.newBuilder().setValue("French").build());
+            entity.putData("language", any);
+
+            var id  = ID.newBuilder().setNs("demo").setEntity("work").addPaths("michael_vorburger").build();
+            entity.putRelated("work", id);
+        }
+
         var response = AugmentResponse.newBuilder().setEntity(entity).build();
         responseObserver.onNext(response);
         responseObserver.onCompleted();

--- a/connectors/demo/src/main/java/dev/enola/demo/DemoConnector.java
+++ b/connectors/demo/src/main/java/dev/enola/demo/DemoConnector.java
@@ -37,12 +37,8 @@ public class DemoConnector extends ConnectorServiceGrpc.ConnectorServiceImplBase
     public void augment(AugmentRequest request, StreamObserver<AugmentResponse> responseObserver) {
         var entity = request.getEntity().toBuilder();
 
-        //dev.enola.core.util
-        var s = Struct.newBuilder();
-        //s.update("k","v");
-
-
-        System.out.println(IDs.toPath(entity.getId()));
+        // these returned values match docs/user/library/model.textproto (and not the yaml version)
+        System.out.println("augment: " + IDs.toPath(entity.getId()));
         if (IDs.toPath(entity.getId()).equals("demo.work/8706-1000")) {
 
             Any any = Any.pack(EnolaString.newBuilder().setValue("En attendant Godot").build());
@@ -56,8 +52,7 @@ public class DemoConnector extends ConnectorServiceGrpc.ConnectorServiceImplBase
 
             var id  = ID.newBuilder().setNs("demo").setEntity("author").addPaths("samuel_beckett").build();
             entity.putRelated("author", id);
-        }
-        if (IDs.toPath(entity.getId()).equals("demo.work/0-13-140731-7")) {
+        } else if (IDs.toPath(entity.getId()).equals("demo.work/0-13-140731-7")) {
 
             Any any = Any.pack(EnolaString.newBuilder().setValue("Core Java data objects").build());
             entity.putData("title", any);
@@ -67,20 +62,20 @@ public class DemoConnector extends ConnectorServiceGrpc.ConnectorServiceImplBase
 
             var id  = ID.newBuilder().setNs("demo").setEntity("author").addPaths("michael_vorburger").build();
             entity.putRelated("author", id);
-        }
-        if (IDs.toPath(entity.getId()).equals("demo.author/samuel_beckett")) {
+        } else if (IDs.toPath(entity.getId()).equals("demo.author/samuel_beckett")) {
             Any any = Any.pack(EnolaString.newBuilder().setValue("French").build());
             entity.putData("language", any);
 
             var id  = ID.newBuilder().setNs("demo").setEntity("work").addPaths("samuel_beckett").build();
             entity.putRelated("work", id);
-        }
-        if (IDs.toPath(entity.getId()).equals("demo.author/michael_vorburger")) {
+        } else if (IDs.toPath(entity.getId()).equals("demo.author/michael_vorburger")) {
             Any any = Any.pack(EnolaString.newBuilder().setValue("French").build());
             entity.putData("language", any);
 
             var id  = ID.newBuilder().setNs("demo").setEntity("work").addPaths("michael_vorburger").build();
             entity.putRelated("work", id);
+        } else {
+            entity.putLink("link1", "http://www.vorburger.ch");
         }
 
         var response = AugmentResponse.newBuilder().setEntity(entity).build();

--- a/core/impl/BUILD
+++ b/core/impl/BUILD
@@ -23,6 +23,7 @@ java_library(
     visibility = [
         "//cli:__subpackages__",
         "//web/ui:__pkg__",
+        "//web/view:__pkg__",
     ],
     deps = [
         "//common/common",

--- a/core/lib/BUILD
+++ b/core/lib/BUILD
@@ -59,6 +59,16 @@ proto_library(
     ],
 )
 
+# proto_library(
+#     name = "view_proto",
+#     srcs = ["src/main/java/dev/enola/core/enola_view.proto"],
+#     deps = [
+#         "@com_google_protobuf//:any_proto",
+#         "@com_google_protobuf//:struct_proto",
+#         "@com_google_protobuf//:timestamp_proto",
+#     ],
+# )
+
 java_proto_library(
     name = "core_java_proto",
     protos = [
@@ -72,6 +82,7 @@ java_proto_library(
         "//connectors:__subpackages__",
         "//core:__subpackages__",
         "//web/ui:__pkg__",
+        "//web/view:__pkg__",
     ],
 )
 
@@ -85,6 +96,7 @@ java_grpc_library(
         "//connectors:__subpackages__",
         "//core:__subpackages__",
         "//web/ui:__pkg__",
+        "//web/view:__pkg__",
     ],
 )
 
@@ -125,6 +137,7 @@ java_library(
         "//connectors:__subpackages__",
         "//core:__subpackages__",
         "//web/ui:__pkg__",
+        "//web/view:__pkg__",
     ],
     deps = [
         ":core_java_proto",

--- a/core/lib/src/main/java/dev/enola/core/enola_core.proto
+++ b/core/lib/src/main/java/dev/enola/core/enola_core.proto
@@ -87,7 +87,8 @@ message Entity {
 
   // Data about the Entity, in machine readable form, as Any protobuf.
   // TODO replace Struct with Any, but that needs schemas... map<string, google.protobuf.Any> data = 9;
-  map<string, google.protobuf.Struct> data = 9;
+  //map<string, google.protobuf.Struct> data = 9;
+  map<string, google.protobuf.Any> data = 9;
 }
 
 message GetEntityRequest {
@@ -122,3 +123,7 @@ message GetEntityResponse {
 service EnolaService {
   rpc GetEntity(GetEntityRequest) returns (GetEntityResponse) {}
 }
+
+
+
+

--- a/core/lib/src/main/java/dev/enola/core/util/enola_util.proto
+++ b/core/lib/src/main/java/dev/enola/core/util/enola_util.proto
@@ -34,6 +34,10 @@ option java_multiple_files = true;
 //   STATUS_NOK_ITSELF = 503;
 // }
 
+message EnolaString {
+  string value = 1;
+}
+
 // TODO Log isn't actually used, just yet...
 message Log {
   oneof oneof {

--- a/docs/use/library/model.textproto
+++ b/docs/use/library/model.textproto
@@ -1,0 +1,112 @@
+kinds {
+  id: { ns: "demo" entity: "work" paths: "isbn" }
+  label: "Book"
+  emoji: "💂"
+  #doc_url: "demo-model.md#foo"
+  connectors :{grpc:"localhost:8080"}
+  data {
+    key: "title"
+  }
+  related {
+    key: "author",
+    value: {
+      label: "Details about the author",
+      id: { ns: "demo" entity: "author" }
+    }
+  }
+  # data {
+  #   key:"isbn",
+  #   value: {
+  #     label: "isbn",
+  #     type_url: "dev.enola.core.util.String"
+  #   }
+  # }
+  related {
+    key: "copies",
+    value: {
+      label: "All the books that publish this work",
+      id: { ns: "demo" entity: "book" }
+    }
+  }
+  data {
+    key: "language",
+    value: {
+      label: "Language",
+      type_url: "dev.enola.core.util.String"
+    }
+  }
+  data {
+    key: "title",
+    value: {
+      label: "Title",
+      type_url: "dev.enola.core.util.String"
+    }
+  }
+  link {
+    key: "search",
+    value: {
+      label: "Search the internet for this work",
+      uri_template: ""
+    }
+  }
+
+  link {
+    key: "wikipedia",
+    value: {
+      label: "Open the wikipedia page for this work",
+      uri_template: ""
+    }
+  }
+}
+
+kinds {
+  id: {
+    ns: "demo"
+    entity: "author"
+    paths: [ "name" ]
+  }
+  connectors :{grpc:"localhost:8080"}
+
+  data {
+    key: "language",
+    value: {
+      label: "Language",
+      type_url: "dev.enola.core.util.String"
+    }
+  }
+
+  related {
+    key: "work",
+    value: {
+      label: "Works by this author",
+      id: { ns: "demo" entity: "work" }
+    }
+  }
+}
+
+kinds {
+  id: {
+    ns: "demo"
+    entity: "book"
+    paths: [ "book", "id" ]
+  }
+  label: "Book instance"
+  emoji: "👩‍🎤"
+  #doc_url: "demo-model.md#bar"
+  related {
+    key: "work",
+    value: {
+      label: "Details about this work",
+      description: ""
+      id: { ns: "demo" entity: "work" }
+    }
+  }
+
+  data {
+    key: "language",
+    value: {
+      label: "Language",
+      type_url: "dev.enola.core.util.String"
+    }
+  }
+}

--- a/docs/use/library/model.yaml
+++ b/docs/use/library/model.yaml
@@ -2,6 +2,7 @@ kinds:
   - id: { ns: demo, entity: book_kind, paths: [isbn] }
     label: Book (Kind)
     emoji: 📗
+    connectors: [{grpc:http://localhost:8080}]
     link:
       google:
         label: Google Book Search

--- a/web/ui/BUILD
+++ b/web/ui/BUILD
@@ -26,6 +26,7 @@ java_library(
     deps = [
         "//common/common",
         "//core/impl",  # TODO Move class Soy, avoid full impl dep
+        "//web/view:view_java_proto",
         "//core/lib:core_java_proto",
         "//core/lib:lib_java",
         "//web/api",

--- a/web/ui/BUILD
+++ b/web/ui/BUILD
@@ -45,6 +45,8 @@ java_library(
         "//common/protobuf",
         "//core/lib:core_java_proto",
         "//core/lib:lib_java",
+        "//core/impl",
+
         "//web/api",
         "//web/sun",
         "@maven//:com_google_truth_truth",

--- a/web/ui/src/main/java/dev/enola/web/ui/UI.java
+++ b/web/ui/src/main/java/dev/enola/web/ui/UI.java
@@ -84,11 +84,14 @@ public class UI implements WebHandler {
     }
 
     private String getHTML(URI uri) throws EnolaException, IOException {
+        System.out.println("+++++++++++++++++++++++");
         var path = uri.getPath();
+        System.out.println("+++++++++++++++++++++++  " + path);
         // TODO implement the to-many relationship
         if (path.startsWith("/ui/entity/")) {
             var idString = path.substring("/ui/entity/".length());
             var id = IDs.parse(idString);
+        System.out.println("+++++++++++++++++++++++  " + id);
             return getEntityHTML(id);
         } else {
             // TODO Create HTML page “frame” from .soy, with body from another .soy
@@ -107,7 +110,11 @@ public class UI implements WebHandler {
         var request = GetEntityRequest.newBuilder().setId(id).build();
         var response = service.getEntity(request);
         Entity entity = response.getEntity();
+        System.out.println("+++++++++++++++++++++++ 11 " + id);
+
         EntityKind ek = ekr.getOptional(entity.getId()).get();
+        System.out.println("+++++++++++++++++++++++ 22 " + id);
+
         var singleEntityView = SingleEntityView.newBuilder();
         singleEntityView.setId(IDs.toPath(entity.getId()));
         singleEntityView.setKindName(entity.getId().getEntity());

--- a/web/ui/src/main/java/dev/enola/web/ui/UI.java
+++ b/web/ui/src/main/java/dev/enola/web/ui/UI.java
@@ -27,9 +27,17 @@ import dev.enola.common.io.resource.ReadableResource;
 import dev.enola.common.io.resource.StringResource;
 import dev.enola.core.EnolaException;
 import dev.enola.core.EnolaService;
+import dev.enola.core.meta.EntityKindRepository;
+import dev.enola.core.util.proto.EnolaString;
+import com.google.protobuf.Any;
+import com.google.protobuf.*;
+
 import dev.enola.core.IDs;
+import dev.enola.view.proto.SingleEntityView;
+import dev.enola.view.proto.ViewItem;
 import dev.enola.core.meta.docgen.Soy;
 import dev.enola.core.proto.Entity;
+import dev.enola.core.meta.proto.EntityKind;
 import dev.enola.core.proto.GetEntityRequest;
 import dev.enola.core.proto.ID;
 import dev.enola.web.StaticWebHandler;
@@ -45,13 +53,17 @@ public class UI implements WebHandler {
     private final Soy soy =
             new Soy.Builder()
                     .addSoy("ui.soy")
-                    .addProto(ID.getDescriptor(), Entity.getDescriptor())
+                    .addProto(
+                        SingleEntityView.getDescriptor(),
+                        ViewItem.getDescriptor())
                     .build();
 
     private final EnolaService service;
+    private final EntityKindRepository ekr;
 
-    public UI(EnolaService service) {
+    public UI(EnolaService service, EntityKindRepository ekr) {
         this.service = service;
+        this.ekr = ekr;
     }
 
     public void register(WebServer server) {
@@ -73,6 +85,7 @@ public class UI implements WebHandler {
 
     private String getHTML(URI uri) throws EnolaException, IOException {
         var path = uri.getPath();
+        // TODO implement the to-many relationship
         if (path.startsWith("/ui/entity/")) {
             var idString = path.substring("/ui/entity/".length());
             var id = IDs.parse(idString);
@@ -83,12 +96,60 @@ public class UI implements WebHandler {
         }
     }
 
+    private String getRelatedRelativePath(ID id, boolean many){
+        var path =  "/ui/entity/" + IDs.toPath(id);
+        return path;
+        // TODO implement the to-many relationship
+    }
+
+
     private String getEntityHTML(ID id) throws EnolaException {
         var request = GetEntityRequest.newBuilder().setId(id).build();
         var response = service.getEntity(request);
-        var entity = response.getEntity();
+        Entity entity = response.getEntity();
+        EntityKind ek = ekr.getOptional(entity.getId()).get();
+        var singleEntityView = SingleEntityView.newBuilder();
+        singleEntityView.setId(IDs.toPath(entity.getId()));
+        singleEntityView.setKindName(entity.getId().getEntity());
+        singleEntityView.setFullName(entity.getId().getNs()+"."+entity.getId().getEntity());
+        for (var kv : entity.getLinkMap().entrySet()){
+            var viewItem = ViewItem.newBuilder()
+                            .setRef(kv.getValue())
+                            .setLabel(kv.getKey())
+                            .build();
+            singleEntityView.addLink(viewItem);
+        }
 
-        Map<String, ?> params = ImmutableMap.of("e", entity);
+        for (var kv : entity.getDataMap().entrySet()){
+            Any any = kv.getValue();
+            String value = "-";
+            try {
+                value = any.unpack(EnolaString.class).getValue();
+            } catch (InvalidProtocolBufferException e){
+                System.out.println(e);
+            }
+            var viewItem = ViewItem.newBuilder()
+                            .setLabel(ek.getDataMap().get(kv.getKey()).getLabel())
+                            .setRef("")
+                            .setValue(value)
+                            .build();
+            singleEntityView.addData(viewItem);
+        }
+        for (var kv : entity.getRelatedMap().entrySet()){
+            var many = true;
+            var tags = ek.getRelatedMap().get(kv.getKey()).getTagsMap();
+            if (tags.containsKey("cardinality") && tags.get("cardinality").equals("one")) {
+                many = false;
+            }
+            var viewItem = ViewItem.newBuilder()
+                            .setLabel(kv.getKey())
+                            .setRef(getRelatedRelativePath(kv.getValue(), many))
+                            .setValue(ek.getRelatedMap().get(kv.getKey()).getLabel())
+                            .build();
+
+            singleEntityView.addRelated(viewItem);
+        }
+        Map<String, ?> params = ImmutableMap.of("sv",singleEntityView.build());
         var renderer = soy.newRenderer("dev.enola.ui.page", params);
         // TODO Make this async - but I don't understand Soy's async API...
         return renderer.renderHtml().get().getContent();

--- a/web/ui/src/main/resources/ui.soy
+++ b/web/ui/src/main/resources/ui.soy
@@ -17,42 +17,35 @@
 {namespace dev.enola.ui}
 
 // see https://github.com/google/closure-templates/issues/1300 re. path
-import {ID} from 'core/lib/src/main/java/dev/enola/core/enola_core.proto';
-import {Entity} from 'core/lib/src/main/java/dev/enola/core/enola_core.proto';
-
-{template id}
-    {@param id: ID}
-    {$id.ns}.{$id.entity}{for $element in $id.pathsList}/{$element}{/for}
-{/template}
-
-{template idHref kind="uri"}
-    {@param id: ID}
-    /ui/entity/{$id.ns}.{$id.entity}{for $element in $id.pathsList}/{$element}{/for}
-{/template}
+import {SingleEntityView} from 'web/view/src/main/java/dev/enola/web/enola_view.proto';
+import {ViewItem} from 'web/view/src/main/java/dev/enola/web/enola_view.proto';
 
 {template entity}
-    {@param e: Entity}
+    {@param sv: SingleEntityView}
 
-    <h1>{id(id: $e.id)}</h1>
+    <h1>{$sv.id}</h1>
+    <h2>{$sv.fullName}</h2>
     <!-- TODO Show <tt>EntityKind#label + #emoji (OR #logo_url ?)</tt> -->
-    <!-- TODO Function to format @ {$e.ts} using class Timestamps2 -->
+    //<!-- TODO Function to format @ {$e.ts} using class Timestamps2 -->
 
     <!-- TODO
     <span class="material-symbols-outlined"> unfold_more </span>
     <i>TODO Show (beginning of) <tt>EntityKind#doc_url</tt> here... (&hellip;)</i>
     -->
 
-    <!-- TODO Only if $e.relatedMap.size() > 0 ... -->
     <h2>Related</h2>
-    <ul>{for $related in $e.relatedMap.entries()}
-        <!-- The follow format (roughly) matches dev.enola.core.IDs#toPath -->
-        <li><a href="{idHref(id: $related.value)}">{$related.key}</a></li>
+    <ul>{for $related in $sv.relatedList}
+        <li><a href="{$related.ref}">{$related.value}</a></li>
     {/for}</ul>
 
-    <!-- TODO Only if $e.linkMap.size() > 0 ... -->
+    <h2>Properties</h2>
+    <ul>{for $data in $sv.dataList}
+        <li>{$data.getLabel()}:"{$data.getValue()}"</li>
+    {/for}</ul>
+
     <h2>Links</h2>
-    <ul>{for $link in $e.linkMap.entries()}
-        <li><a href="{$link.value}">{$link.key}</a></li>
+    <ul>{for $link in $sv.linkList}
+        <li><a href="{$link.ref}">{$link.label}</a></li>
     {/for}</ul>
 
     <!-- TODO Show <tt>data</tt>... how - as TextProto? -->
@@ -74,7 +67,7 @@ import {Entity} from 'core/lib/src/main/java/dev/enola/core/enola_core.proto';
 {/template}
 
 {template page}
-    {@param e: Entity}
+    {@param sv: SingleEntityView}
     // TODO How-to? <!DOCTYPE html>
     <html>
     <head>
@@ -114,7 +107,7 @@ import {Entity} from 'core/lib/src/main/java/dev/enola/core/enola_core.proto';
         <div style="float: right; padding-top: 1em"><a href="#">name</a>: <input value="demo"/></div>
 
         <div style="float: let">
-            {entity(e: $e)}
+            {entity(sv: $sv)}
         </div>
     </div>
     </body>

--- a/web/ui/src/test/java/dev/enola/web/ui/UiTest.java
+++ b/web/ui/src/test/java/dev/enola/web/ui/UiTest.java
@@ -44,7 +44,7 @@ public class UiTest {
     public void testUi() throws IOException {
         var addr = new InetSocketAddress(0);
         try (var server = new SunServer(addr)) {
-            new UI(new TestService()).register(server);
+            new UI(new TestService(), null).register(server);
             server.start();
             var rp = new ResourceProviders();
             var port = server.getInetAddress().getPort();

--- a/web/ui/src/test/resources/demo-model.textproto
+++ b/web/ui/src/test/resources/demo-model.textproto
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2023 The Enola <https://enola.dev> Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# https://protobuf.dev/reference/protobuf/textformat-spec/
+# proto-file: dev/enola/core/meta/enola_meta.proto
+# proto-message: EntityKinds
+
+kinds {
+  id: { ns: "demo" entity: "foo" paths: "name" }
+  label: "Fo-o"
+  emoji: "💂"
+  doc_url: "demo-model.md#foo"
+}
+kinds {
+  id: {
+    ns: "demo"
+    entity: "bar"
+    paths: [ "foo", "name" ]
+  }
+  label: "FUBAR?"
+  emoji: "👩‍🎤"
+  doc_url: "demo-model.md#bar"
+  related {
+    key: "foo",
+    value: {
+      label: "Foo link",
+      description: "This is the 'parent' Foo."
+      id: { ns: "demo" entity: "foo" }
+    }
+  }
+  related {
+    key: "one",
+    value: {
+      label: "Primary Baz",
+      id: { ns: "demo" entity: "baz" }
+    }
+  }
+  related {
+    key: "two",
+    value: {
+      label: "Secondary Baz",
+      description: "There is always moar to relate to!",
+      id: { ns: "demo" entity: "baz" }
+    }
+  }
+  link {
+    key: "wiki",
+    value: {
+      label: "Wikipedia",
+      description: "founded by Jimmy Wales",
+      uri_template: "https://en.wikipedia.org/w/index.php?fulltext=Search&search={name}"
+    }
+  }
+  link {
+    key: "zzz"
+    value: {
+      label: "Backend"
+      description: "Linked Data in another system"
+      uri_template: "localhost:50051"  # TODO ???
+    }
+  }
+}
+kinds { id: { ns: "demo" entity: "baz" paths: "uuid" } }

--- a/web/view/BUILD
+++ b/web/view/BUILD
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2023 The Enola <https://enola.dev> Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_java//java:defs.bzl", "java_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_proto_grpc//java:defs.bzl", "java_grpc_library", "java_proto_library")
+
+proto_library(
+    name = "view_proto",
+    srcs = ["src/main/java/dev/enola/web/enola_view.proto"],
+    deps = [
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:struct_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+java_proto_library(
+    name = "view_java_proto",
+    protos = [
+        "view_proto",
+    ],
+    visibility = [
+        "//cli:__subpackages__",
+        "//web/ui:__pkg__",
+    ],
+)
+
+# java_library(
+#     name = "api",
+#     srcs = glob(["src/main/java/**/*.java"]),
+#     visibility = [
+#         "//web:__subpackages__",
+#     ],
+#     deps = [
+#         "//common/common",
+#         "@maven//:com_google_guava_guava",
+#     ],
+# )

--- a/web/view/src/main/java/dev/enola/web/enola_view.proto
+++ b/web/view/src/main/java/dev/enola/web/enola_view.proto
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright 2023 The Enola <https://enola.dev> Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package dev.enola.view;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+
+option java_string_check_utf8 = true;
+option java_package = "dev.enola.view.proto";
+option java_multiple_files = true;
+
+message SingleEntityView {
+  string id = 1;
+  string kind_name = 2;
+  string full_name = 3;
+  repeated ViewItem data = 4;
+  repeated ViewItem related = 5;
+  repeated ViewItem link = 6;
+}
+
+message ViewItem {
+  string label = 1;
+  string ref = 2;
+  string value = 3;
+}


### PR DESCRIPTION
Relates to | Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] `./test.bash` passes locally
- [ ] Appropriate changes to documentation are included in the PR
