### PR TITLE
go_proto_library

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -47,3 +47,15 @@ maven.install(
     lock_file = "//:maven_install.json",
 )
 use_repo(maven, "maven", "unpinned_maven")
+
+# https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/bzlmod.md
+bazel_dep(name = "rules_go", version = "0.39.1", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "gazelle", version = "0.30.0", repo_name = "bazel_gazelle")
+
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+# go_sdk.host()
+go_sdk.download(
+    version = "1.20.3",
+    goarch = "amd64",
+    goos = "linux",
+)

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -78,6 +78,44 @@ compat_repositories()
 
 grpc_java_repositories()
 
+# https://github.com/rules-proto-grpc/rules_proto_grpc/blob/master/example/go/go_proto_library/WORKSPACE
+
+load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_repos", "rules_proto_grpc_toolchains")
+
+rules_proto_grpc_toolchains()
+
+rules_proto_grpc_repos()
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
+rules_proto_dependencies()
+
+rules_proto_toolchains()
+
+# https://rules-proto-grpc.com/en/latest/lang/go.html#go-proto-library
+
+load("@rules_proto_grpc//:repositories.bzl", "bazel_gazelle", "io_bazel_rules_go")  # buildifier: disable=same-origin-load
+
+io_bazel_rules_go()
+
+bazel_gazelle()
+
+load("@rules_proto_grpc//go:repositories.bzl", rules_proto_grpc_go_repos = "go_repos")
+
+rules_proto_grpc_go_repos()
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains(
+    version = "1.17.1",
+)
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+gazelle_dependencies()
+
 # https://github.com/bazelbuild/rules_closure/#setup
 # TODO This is only useful after https://github.com/bazelbuild/rules_closure/issues/225
 #http_archive(

--- a/core/lib/BUILD
+++ b/core/lib/BUILD
@@ -27,6 +27,20 @@ load("@rules_proto_grpc//doc:defs.bzl", "doc_markdown_compile")
 # https://rules-proto-grpc.com/en/latest/lang/java.html#java-proto-library
 load("@rules_proto_grpc//java:defs.bzl", "java_grpc_library", "java_proto_library")
 
+# https://rules-proto-grpc.com/en/latest/lang/go.html#go-proto-library
+load("@rules_proto_grpc//go:defs.bzl", "go_proto_library")
+
+go_proto_library(
+    name = "proto_go_proto",
+    # ? importpath = "github.com/rules-proto-grpc/rules_proto_grpc/example/proto",
+    protos = [
+        ":core_proto",
+        ":connector_proto",
+        ":meta_proto",
+        ":util_proto",
+    ],
+)
+
 # https://rules-proto-grpc.com/en/latest/example.html#step-3-write-a-build-file
 proto_library(
     name = "core_proto",


### PR DESCRIPTION
@digitalentity FYI this is some progress, the error is no longer the original one, but `./test.bash` now fails with:

```
$ b test //...
ERROR: Traceback (most recent call last):
        File "~/.cache/bazel/_bazel_vorburger/9e91208784b864033477b3d14a0a67c6/external/go_sdk/BUILD.bazel", line 3, column 41, in <toplevel>
                load("@io_bazel_rules_go//go:def.bzl", "declare_toolchains", "go_sdk")
Error: file '@io_bazel_rules_go//go:def.bzl' does not contain symbol 'declare_toolchains'
ERROR: ~/enola/cli/BUILD:19:12: While resolving toolchains for target //cli:enola: invalid registered toolchain '@go_sdk//:go_android_386': no such target '@go_sdk//:go_android_386': target 'go_android_386' not declared in package '' defined by ~/.cache/bazel/_bazel_vorburger/9e91208784b864033477b3d14a0a67c6/external/go_sdk/BUILD.bazel (Tip: use `query "@go_sdk//:*"` to see all the targets in that package)
```

The missing toolchain keeps changing, sometimes it's `@go_sdk//:go_android_386` and sometimes it's `@go_sdk//:go_aix_ppc64` and sometimes `'@go_sdk//:go_windows_arm64` and `@go_sdk//:go_netbsd_amd64`.

I'm sure we'll eventually figure this out...