### PR TITLE
chore(deps): Bump rules_jvm_external from 5.1 to 5.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@
 
 # https://github.com/bazelbuild/rules_jvm_external/blob/master/docs/bzlmod.md#installation
 # When bumping the version here, must always run: REPIN=1 bazel run @unpinned_maven//:pin
-bazel_dep(name = "rules_jvm_external", version = "5.1")
+bazel_dep(name = "rules_jvm_external", version = "5.2")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(


### PR DESCRIPTION
This unfortunately does not fix https://github.com/bazelbuild/rules_jvm_external/issues/910 which is being encountered on #161.
