### PR TITLE
Add Go build rules, go_proto_library and Enola core_go_proto library

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -48,3 +48,16 @@ maven.install(
     lock_file = "//:maven_install.json",
 )
 use_repo(maven, "maven", "unpinned_maven")
+
+# https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/bzlmod.md
+bazel_dep(name = "rules_go", version = "0.39.1", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "gazelle", version = "0.30.0", repo_name = "bazel_gazelle")
+
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+
+# go_sdk.host()
+go_sdk.download(
+    goarch = "amd64",
+    goos = "linux",
+    version = "1.20.3",
+)

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -74,6 +74,37 @@ compat_repositories()
 
 grpc_java_repositories()
 
+rules_proto_grpc_toolchains()
+
+rules_proto_grpc_repos()
+
+rules_proto_dependencies()
+
+rules_proto_toolchains()
+
+# https://rules-proto-grpc.com/en/latest/lang/go.html#go-proto-library
+# load("@rules_proto_grpc//:repositories.bzl", "bazel_gazelle", "io_bazel_rules_go")
+
+# io_bazel_rules_go()
+
+# bazel_gazelle()
+
+# load("@rules_proto_grpc//go:repositories.bzl", rules_proto_grpc_go_repos = "go_repos")
+
+# rules_proto_grpc_go_repos()
+
+# load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+# go_rules_dependencies()
+
+# go_register_toolchains(
+#     version = "1.17.1",
+# )
+
+# load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+# gazelle_dependencies()
+
 # https://github.com/bazelbuild/rules_closure/#setup
 # TODO This is only useful after https://github.com/bazelbuild/rules_closure/issues/225
 #http_archive(

--- a/core/lib/BUILD
+++ b/core/lib/BUILD
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# https://github.com/bazelbuild/rules_go/blob/master/proto/core.rst#go_proto_library
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
 # https://github.com/enola-dev/enola/issues/202
 # https://github.com/grpc/grpc-java/issues/10215
 # TODO replace with bazel_dep in MODULE.bazel
@@ -165,3 +168,21 @@ java_library(
 ) for name in glob([
     "src/test/java/**/*Test.java",
 ])]
+
+go_proto_library(
+    name = "core_go_proto",
+    importpath = "dev/enola/core",
+    protos = [
+        ":connector_proto",
+        ":core_proto",
+        ":meta_proto",
+        ":util_proto",
+    ],
+    visibility = [
+        "//cli:__subpackages__",
+        "//connectors:__subpackages__",
+        "//core:__subpackages__",
+        "//web/rest:__pkg__",
+        "//web/ui-soy:__pkg__",
+    ],
+)

--- a/core/lib/src/main/java/dev/enola/core/enola_core.proto
+++ b/core/lib/src/main/java/dev/enola/core/enola_core.proto
@@ -25,6 +25,7 @@ import "google/protobuf/timestamp.proto";
 option java_string_check_utf8 = true;
 option java_package = "dev.enola.core.proto";
 option java_multiple_files = true;
+option go_package = "dev/enola/core";
 
 // ID of an Entity known to Enola, fully qualified.
 // Can be formatted to and parsed from several different string text forms,


### PR DESCRIPTION
Supersedes #199

- [x] `./test.bash` passes locally
- [ ] Appropriate changes to documentation are included in the PR
  - not necessary AFAICT