### PR TITLE
fix (build): Consistently use proto instead protos in go_proto_library

### DIFF
--- a/core/lib/BUILD
+++ b/core/lib/BUILD
@@ -177,9 +177,7 @@ java_library(
 go_proto_library(
     name = "core_go_proto",
     importpath = "dev/enola/core",
-    protos = [
-        ":core_proto",
-    ],
+    proto = ":core_proto",
     visibility = [],
 )
 


### PR DESCRIPTION
Relates to #242
