### PR TITLE
fix (build): Use go_sdk.host() instead of go_sdk.download(..linux..)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -55,9 +55,4 @@ bazel_dep(name = "gazelle", version = "0.31.1", repo_name = "bazel_gazelle")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 
-# go_sdk.host()
-go_sdk.download(
-    goarch = "amd64",
-    goos = "linux",
-    version = "1.20.4",
-)
+go_sdk.host(version = "1.20.4")


### PR DESCRIPTION
Relates to #246
