### PR TITLE
fix  (docs): Run ExecMD for all *.md (and other docz fixes)

### DIFF
--- a/core/lib/src/main/java/dev/enola/core/meta/enola_meta.proto
+++ b/core/lib/src/main/java/dev/enola/core/meta/enola_meta.proto
@@ -30,10 +30,6 @@ option go_package = "dev/enola/core/meta";
 // TODO Enable this, with validation that entities don't have it, and
 // "complete" it on read string package = 1;
 
-// List of entities kinds of this model.
-// repeated EntityKind entities = 2;
-// }
-
 message EntityKinds {
   repeated EntityKind kinds = 1;
 }

--- a/docs/use/execmd/index.md
+++ b/docs/use/execmd/index.md
@@ -31,7 +31,7 @@ A code block such as this one in [`demo.md`](../../../docs/use/execmd/demo.md):
     ```
 ```
 
-when ran through `./enola execmd docs/use/execmd/index.md` produces:
+when ran through `./enola execmd docs/use/execmd/demo.md` produces:
 
 ```bash
 $ echo Hi

--- a/docs/use/help/index.md
+++ b/docs/use/help/index.md
@@ -31,14 +31,14 @@ $ ./enola
 ...
 ```
 
-Each sub-command's help can be shown either with `enola help SUBCOMMAND` or `enola SUBCOMMAND --help`.
+Each sub-command's help can be shown either with `enola help SUBCOMMAND` (better) or `enola SUBCOMMAND --help` (not recommended).
 
 ## DocGen
 
 [Documentation Generation](../docgen/index.md) has the following options:
 
-```bash $? cd .././.././..
-$ ./enola docgen --help
+```bash cd .././.././..
+$ ./enola help docgen
 ...
 ```
 
@@ -46,8 +46,8 @@ $ ./enola docgen --help
 
 [Get Entity](../get/index.md) has the following options:
 
-```bash $? cd .././.././..
-$ ./enola get --help
+```bash cd .././.././..
+$ ./enola help get
 ...
 ```
 
@@ -55,8 +55,8 @@ $ ./enola get --help
 
 [List Entities](../list/index.md) has the following options:
 
-```bash $? cd .././.././..
-$ ./enola list --help
+```bash cd .././.././..
+$ ./enola help list
 ...
 ```
 
@@ -66,8 +66,8 @@ Because Entity Kinds are Entites themselves, `list` [can also be used to see the
 
 [The built-in HTTP Web Server](../server/index.md) has the following options:
 
-```bash $? cd .././.././..
-$ ./enola server --help
+```bash cd .././.././..
+$ ./enola help server
 ...
 ```
 
@@ -75,8 +75,8 @@ $ ./enola server --help
 
 [Executable Markdown](../execmd/index.md) has the following options:
 
-```bash $? cd .././.././..
-$ ./enola execmd --help
+```bash cd .././.././..
+$ ./enola help execmd
 ...
 ```
 
@@ -84,8 +84,8 @@ $ ./enola execmd --help
 
 [Rosetta](../rosetta/index.md) has the following options:
 
-```bash $? cd .././.././..
-$ ./enola rosetta --help
+```bash cd .././.././..
+$ ./enola help rosetta
 ...
 ```
 

--- a/tools/demo/build.bash
+++ b/tools/demo/build.bash
@@ -18,15 +18,14 @@
 set -euo pipefail
 
 SCRIPT_DIR=$(realpath "$1")
-MD=$(realpath "$SCRIPT_DIR/index.md")
 SCRIPT=$(realpath "$SCRIPT_DIR/script")
 TOOLS_DIR=$(realpath "$(dirname "$0")")
 ENOLA="$TOOLS_DIR"/../../enola
 CWD=$(pwd)
 cd "$SCRIPT_DIR"
 
-echo ./enola execmd -i "$MD" ...
-"$ENOLA" -vvvvvvv execmd -i "$MD"
+echo ./enola execmd -i "$SCRIPT_DIR"/*.md ...
+"$ENOLA" -vvvvvvv execmd -i "$SCRIPT_DIR"/*.md
 
 # This script produces https://asciinema.org-like documentation from demo scripts!
 # It uses the great https://github.com/zechris/asciinema-rec_script to achieve this.


### PR DESCRIPTION
This fixes the currently broken https://docs.enola.dev/use/list/schema/ page.
