### PR TITLE
fix(deps): Work around to enable Bazel version upgrades in upcoming future PRs

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,6 +18,8 @@
 # When bumping the version here, must always run: REPIN=1 bazel run @unpinned_maven//:pin
 bazel_dep(name = "rules_jvm_external", version = "5.3")
 
+# TODO Declare Maven dependencies in 1 single place, instead of both here
+# as well as in maven_install() of WORKSPACE.bazel; try moving that here?
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
     artifacts = [

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -58,7 +58,9 @@ load(
 )
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 
+# TODO Declare Maven dependencies in 1 single place, instead of both here as well as in maven.install() of MODULE.bazel
 maven_install(
+    name = "rules_jvm_external_maven",
     artifacts = IO_GRPC_GRPC_JAVA_ARTIFACTS,
     generate_compat_repositories = True,
     override_targets = IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS,
@@ -67,7 +69,7 @@ maven_install(
     ],
 )
 
-load("@maven//:compat.bzl", "compat_repositories")
+load("@rules_jvm_external_maven//:compat.bzl", "compat_repositories")
 
 compat_repositories()
 

--- a/cli/src/test/java/dev/enola/cli/ClasspathHellDuplicatesCheckerTest.java
+++ b/cli/src/test/java/dev/enola/cli/ClasspathHellDuplicatesCheckerTest.java
@@ -75,6 +75,10 @@ public class ClasspathHellDuplicatesCheckerTest {
         // Bazel Rules etc. not runtime classpath
         return jarPath.contains("java_tools/Runner_deploy.jar")
 
+                // TODO Declare Maven dependencies in 1 single place, instead of both in
+                // maven.install() of MODULE.bazel and in maven_install() of WORKSPACE.bazel.
+                || jarPath.contains("/external/rules_jvm_external%7e5.3%7emaven%7emaven/")
+
                 // TODO: Fix the sad mess :( of duplicate Protobuf & gRPC JARs!
                 || jarPath.contains("protobuf")
                 || jarPath.contains("grpc");


### PR DESCRIPTION
This works around the https://github.com/bazelbuild/rules_jvm_external/issues/910 problem.

It will help to enable upgrading Bazel (e.g. #161, although I will probably go about it more step by step).