### PR TITLE
feat  (cli): Introduce Enola container image for end-users

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -83,6 +83,12 @@ max_line_length = unset
 [.bazelproject]
 indent_size = 2
 
+[ci.yaml]
+max_line_length = unset
+
+[Dockerfile]
+max_line_length = unset
+
 # Note that https://github.com/editorconfig-checker/editorconfig-checker
 # which https://github.com/editorconfig-checker/editorconfig-checker.python
 # uses does not understand e.g. [{*.yaml,*.yml}] but only single ones.

--- a/.editorconfig
+++ b/.editorconfig
@@ -24,10 +24,7 @@ indent_size = unset
 tab_width = unset
 
 # The ./enola* files are Bash scripts (without *.bash extension)
-[enola]
-indent_size = 2
-tab_width = 2
-[enola-dl]
+[enola*]
 indent_size = 2
 tab_width = 2
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,13 +40,15 @@ jobs:
       - name: Cache Bazel
         uses: actions/cache@v3
         with:
+          # KEEP IN SYNC WITH BELOW!
           # https://github.com/actions/cache/pull/575/files
           path: |
             ~/.cache/bazel/
             ~/.cache/bazelisk/
             /private/var/tmp/_bazel_runner/
           key: >
-            ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE.bazel', 'MODULE.bazel') }}
+            ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc',
+            'WORKSPACE.bazel', 'MODULE.bazel') }}
           restore-keys: ${{ runner.os }}-bazel-
       - name: Cache Python
         uses: actions/cache@v3
@@ -65,7 +67,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/pre-commit/
-          key: ${{ runner.os }}-cache-${{ hashFiles('.pre-commit-config.yaml') }}
+          key:
+            ${{ runner.os }}-cache-${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: ${{ runner.os }}-cache-
       - name: Cache Demo
         uses: actions/cache@v3
@@ -110,3 +113,56 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2
+
+  # https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#publishing-a-package-using-an-action
+  push-container-image:
+    needs: build
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    # This is a separate job from 'build' only because it needs additional permissions which we don't want 'build' to have:
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache Bazel
+        uses: actions/cache@v3
+        with:
+          # KEEP IN SYNC WITH ABOVE!
+          # https://github.com/actions/cache/pull/575/files
+          path: |
+            ~/.cache/bazel/
+            ~/.cache/bazelisk/
+            /private/var/tmp/_bazel_runner/
+          key: >
+            ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc',
+            'WORKSPACE.bazel', 'MODULE.bazel') }}
+          restore-keys: ${{ runner.os }}-bazel-
+      - name: Build Container Image # again, because technically it was already built in the 'build' job, but oh well!
+        run: ./tools/distro/build.bash
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM gcr.io/distroless/java21-debian12:nonroot
+
+# Loosely inspired by https://github.com/GoogleContainerTools/distroless/blob/main/examples/java/Dockerfile
+
+# For consistency, use Enola's standard "distro"
+# (instead of e.g. directly COPY bazel-bin/cli/enola_deploy.jar)...
+
+# ...BUT note that we still CANNOT just do e.g. ENTRYPOINT ["enola"],
+# because in a (non :debug!) distroless we (intentionally!) do not
+# even have any shell - so we still just have to "java -jar enola".
+
+# Nota bene: The /app/CWD/ and ../enola circus is to be able to use
+# 'docker run ... -v "$PWD":/app/CWD/:Z' in the 'enola-c' launch script;
+# see docs/use/index.md.
+
+WORKDIR /app/CWD/
+COPY --chmod=0777 --chown=nonroot:nonroot site/download/latest/enola /app/enola
+ENTRYPOINT [ "java", "-jar", "../enola" ]
+
+# To debug, replace FROM :nonroot with :debug-nonroot,
+# and use ENTRYPOINT [ "/busybox/sh" ] instead of above,
+# and then "docker run" WITHOUT any additional arguments.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM gcr.io/distroless/java21-debian12:nonroot
 
+# https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images
+LABEL org.opencontainers.image.source=https://github.com/enola-dev/enola
+LABEL org.opencontainers.image.description="https://Enola.dev"
+LABEL org.opencontainers.image.licenses=Apache-2.0
+
 # Loosely inspired by https://github.com/GoogleContainerTools/distroless/blob/main/examples/java/Dockerfile
 
 # For consistency, use Enola's standard "distro"

--- a/docs/download/latest/enolac
+++ b/docs/download/latest/enolac
@@ -15,17 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO Replace this shell script with Bazel targets?
+set -euo pipefail
+: "${ENOLA_IMAGE:=ghcr.io/enola-dev/enola:latest}"
 
-mkdir -p site/download/latest/
-set -euox pipefail
+set -x
+docker run --rm --volume "$PWD":/app/CWD/:Z --tty "$ENOLA_IMAGE" "$@"
 
-# Build the end-user distributed executable fat über JAR
-# NB: "bazelisk build //..." does *NOT* build "//cli:enola_deploy.jar", for some reason
-bazelisk build //cli:enola_deploy.jar
-cp tools/distro/execjar-header.bash site/download/latest/enola
-cat bazel-bin/cli/enola_deploy.jar >>site/download/latest/enola
-
-# Build the Container Image
-# NB: This must work both on Docker (which turns it into docker buildx build) and Podman!
-docker build -t localhost/enola:latest .
+# NB: --tty is required so that output is colourful
+# PS: --interactive is not used, because Enola normally doesn't read from STDIN
+# (and it breaks CI/CD, due to "the input device is not a TTY").

--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -39,3 +39,15 @@ once a day or so.
 Of course, whether you are comfortable with such _"Continuous Delivery",_ and thus
 _"always living at `HEAD`",_ like in _"rolling release distros",_ or have any concerns
 with such an approach e.g. from a security perspective, is entirely your choice - YMMV.
+
+## Container
+
+[`enolac`](../download/latest/enolac) runs Enola from a Container, on Docker (or Podman,
+or CRI-O; locally or e.g. on Kubernetes).
+
+It takes the exact same CLI arguments as the "regular" `enola` binary, but pulls it
+via a container image, instead of a "local installation", as above.
+
+It appropriately "mounts" the current working directory into the container, so that
+relative `file:` URIs should work. Absolute paths on your host won't work, because they
+are not accessible to the container ("by design").

--- a/test.bash
+++ b/test.bash
@@ -32,6 +32,9 @@ echo
 echo $ b build //...
 bazelisk build //...
 
+# Test distros: 1. End-user distributed executable fat über JAR, 2. Container Image
+tools/distro/test.bash
+
 # Check if https://pre-commit.com is available (and try to install it not)
 if ! [ -e "./.venv/bin/pre-commit" ]; then
   echo "https://pre-commit.com is not available..."

--- a/tools/distro/test.bash
+++ b/tools/distro/test.bash
@@ -15,17 +15,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO Replace this shell script with Bazel targets?
-
-mkdir -p site/download/latest/
+# TODO Transform this into a Bazel target instead...
 set -euox pipefail
 
-# Build the end-user distributed executable fat über JAR
-# NB: "bazelisk build //..." does *NOT* build "//cli:enola_deploy.jar", for some reason
-bazelisk build //cli:enola_deploy.jar
-cp tools/distro/execjar-header.bash site/download/latest/enola
-cat bazel-bin/cli/enola_deploy.jar >>site/download/latest/enola
+tools/distro/build.bash
 
-# Build the Container Image
-# NB: This must work both on Docker (which turns it into docker buildx build) and Podman!
-docker build -t localhost/enola:latest .
+# TODO Test output
+site/download/latest/enola help
+site/download/latest/enola --version
+site/download/latest/enola get --model file:docs/use/library/model.yaml demo.book_kind/0-13-140731-7
+
+# TODO Test output
+ENOLA_IMAGE=localhost/enola:latest docs/download/latest/enolac help
+ENOLA_IMAGE=localhost/enola:latest docs/download/latest/enolac --version
+ENOLA_IMAGE=localhost/enola:latest docs/download/latest/enolac \
+  get --model file:docs/use/library/model.yaml demo.book_kind/0-13-140731-7


### PR DESCRIPTION
Relates to #180 re. #181.

This PR does not actually publish the container image to `ghcr.io/enola-dev/enola:latest` just yet.