### PR TITLE
fix(dist): ghcr.io/enola-dev/enola :main instead of :latest (see #396)

### DIFF
--- a/docs/download/latest/enolac
+++ b/docs/download/latest/enolac
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 set -euo pipefail
-: "${ENOLA_IMAGE:=ghcr.io/enola-dev/enola:latest}"
+: "${ENOLA_IMAGE:=ghcr.io/enola-dev/enola:main}"
 
 set -x
 docker run --rm --volume "$PWD":/app/CWD/:Z --tty "$ENOLA_IMAGE" "$@"


### PR DESCRIPTION
Fixes #181, see #396.