### PR TITLE
chore(deps): Bump rules_java version from ? to 7.3.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# https://registry.bazel.build/modules/rules_java
+bazel_dep(name = "rules_java", version = "7.3.2")
+
 # https://github.com/bazelbuild/rules_jvm_external/blob/master/docs/bzlmod.md#installation
 # When bumping the version here, must always run: REPIN=1 bazel run @unpinned_maven//:pin
 bazel_dep(name = "rules_jvm_external", version = "5.3")


### PR DESCRIPTION
Motivated by https://github.com/bazelbuild/bazel/issues/18743, in the context of https://github.com/salesforce/bazel-vscode-java/issues/85.
