### PR TITLE
chore(deps): Bump rules_java version from ? to 7.2.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# https://registry.bazel.build/modules/rules_java
+bazel_dep(name = "rules_java", version = "7.2.0")
+
 # https://github.com/bazelbuild/rules_jvm_external/blob/master/docs/bzlmod.md#installation
 # When bumping the version here, must always run: REPIN=1 bazel run @unpinned_maven//:pin
 bazel_dep(name = "rules_jvm_external", version = "5.3")

--- a/common/common/src/test/java/dev/enola/common/io/resource/ClasspathUrlResourceTest.java
+++ b/common/common/src/test/java/dev/enola/common/io/resource/ClasspathUrlResourceTest.java
@@ -102,8 +102,13 @@ public class ClasspathUrlResourceTest {
                 Optional.of(Charsets.UTF_8),
                 "🕵🏾‍♀️\n");
 
-        checkBinary("test.md", OCTET_STREAM, 19);
+        var md = "# Markdown\n\n❤️\n";
+        checkText(
+                "test.md",
+                MediaType.create("text", "markdown").withCharset(Charsets.UTF_8),
+                Optional.of(Charsets.UTF_8),
+                md);
         var resource = new UrlResource(Resources.getResource("test.md"), UTF_8);
-        assertThat(resource.charSource().read()).isEqualTo("# Markdown\n\n❤️\n");
+        assertThat(resource.charSource().read()).isEqualTo(md);
     }
 }


### PR DESCRIPTION
Originally motivated by https://github.com/bazelbuild/bazel/issues/18743, in the context of https://github.com/salesforce/bazel-vscode-java/issues/85,

but as noted in https://github.com/bazelbuild/rules_java/issues/159 from https://github.com/enola-dev/enola/pull/427 I can't go to 7.3.2 just yet - but bumping at least already to 7.2.0 is a first step!
