### PR TITLE
fix (build): Build Container Image with Java 21 as well

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: "temurin"
+          # NB: Repeated below in push-container-image: job; must keep in sync!
           java-version: "21"
 
       - name: Cache Bazel
@@ -133,6 +134,11 @@ jobs:
       IMAGE_NAME: ${{ github.repository }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          # NB: Repeated above in build: job; must keep in sync!
+          java-version: "21"
       - name: Cache Bazel
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
This should fix the [currently broken `main` branch build](https://github.com/enola-dev/enola/actions?query=branch%3Amain).