### PR TITLE
feat  (ide): Bump Google Code Formatter from 1.19.2 to (native!) 1.20.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -112,7 +112,7 @@ repos:
     hooks:
       - id: pretty-format-java
         # Keep this version in sync with the same version in .vscode/settings.json
-        args: [--autofix, --aosp, --google-java-formatter-version=1.19.2]
+        args: [--autofix, --aosp, --google-java-formatter-version=1.20.0]
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.12.1

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -71,7 +71,7 @@
   "java.format.settings.google.extra": "--aosp", // For 4 instead of 2 spaces!
   // Keep this version in sync with the same version in .pre-commit-config.yaml
   // NB: Changes to this are only taken into account on start-up, so need to restart.
-  "java.format.settings.google.version": "1.19.2",
+  "java.format.settings.google.version": "1.20.0",
   // TODO https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3050
   "java.compile.nullAnalysis.mode": "automatic",
   "java.completion.importOrder": ["#", "", "javax", "java"], //# is static


### PR DESCRIPTION
https://github.com/JoseVSeb/google-java-format-for-vs-code/issues/17#issuecomment-1951339052

https://github.com/google/google-java-format/commits/master/?author=vorburger

https://github.com/google/google-java-format/issues/868
