### PR TITLE
fix (build): make devenv work on older debian

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -9,6 +9,8 @@
 # asdf local protoc latest
 
 protoc 25.3
+golang 1.22.0
+java openjdk-21
 
 # TODO protolint here instead of installing it in test.bash
 # when https://github.com/spencergilbert/asdf-protolint/issues/37 is fixed

--- a/Dockerfile-DevEnv
+++ b/Dockerfile-DevEnv
@@ -29,27 +29,29 @@
 #  from https://github.com/devcontainers/templates/tree/main/src/debian
 #  is very (too) minimal, and we would need to add a lot...)
 # FROM mcr.microsoft.com/devcontainers/universal:2-linux
-FROM docker.io/library/fedora:39
+FROM docker.io/library/debian:11
 
-RUN dnf update -y
+RUN apt update -y
 
-RUN dnf install -y fish gcc-c++ golang \
-    java-21-openjdk-devel java-21-openjdk-src java-21-openjdk-javadoc \
-    java-21-openjdk-javadoc-zip java-21-openjdk-jmods
+RUN apt install -y fish g++ git curl unzip -y
 
 # TODO useradd --shell fish ...
-RUN useradd "developer" && \
-    sed -i 's/# %wheel/%wheel/' /etc/sudoers && \
-    sudo usermod -aG wheel "developer"
+RUN adduser "developer"
+# && \
+#    sed -i 's/# %wheel/%wheel/' /etc/sudoers && \
+#    sudo usermod -aG wheel "developer"
 USER developer
 
 # https://go.dev/doc/install (adapted for Fedora, which does not use ~/.profile, and ignores PATH in ~/.bash_profile)
 RUN echo "export PATH=$PATH:/home/developer/go/bin" >> /home/developer/.bashrc
 
-ADD tools/go/install.bash /tmp/go-install.bash
-RUN /tmp/go-install.bash
-
 WORKDIR /workspace/
-RUN --mount=type=bind,source=.,target=/workspace/ /workspace/tools/devenv/install.bash
+ADD tools /workspace/tools
+ADD .tool-versions /workspace/
+
+RUN /workspace/tools/devenv/install.bash
+
+RUN echo "export PATH=$PATH:/home/developer/.asdf/installs/golang/1.22.0/packages/bin" >> /home/developer/.bashrc
+RUN echo ". /home/developer/.asdf/asdf.sh" >> /home/developer/.bashrc
 
 # See https://docs.docker.com/build/guide/mounts/ for documentation about --mount=type.

--- a/devenv.bash
+++ b/devenv.bash
@@ -21,4 +21,4 @@ set -euo pipefail
 
 docker build -t enola.dev-devenv --rm -f Dockerfile-DevEnv .
 
-docker run -v .:/workspace/:Z -it --rm enola.dev-devenv
+docker run -v $PWD:/workspace/:Z -it --rm enola.dev-devenv

--- a/tools/asdf/install.bash
+++ b/tools/asdf/install.bash
@@ -18,11 +18,14 @@
 set -euo pipefail
 
 if ! [ -x "$(command -v asdf)" ]; then
-  echo "Please install ASDF, see https://asdf-vm.com/guide/getting-started.html"
-  # Ideally the same version as the one specified by asdf_branch in ci.yaml
-  exit 1
+  git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.14.0
+  . "$HOME/.asdf/asdf.sh"
 fi
 
 asdf info
+asdf plugin add protoc
+asdf plugin add java
+asdf plugin add golang
 asdf install
 asdf current
+

--- a/tools/devenv/install.bash
+++ b/tools/devenv/install.bash
@@ -19,7 +19,11 @@ set -euo pipefail
 
 # This script prepares the Development Environment container.
 
-tools/pre-commit/install.bash
+tools/asdf/install.bash
+. "$HOME/.asdf/asdf.sh"
+asdf reshim
+tools/go/install.bash
+#tools/pre-commit/install.bash
 
 # TODO After https://github.com/enola-dev/enola/pull/452, uncomment:
 # $(go env GOPATH)/bin/bazelisk run //tools/hello


### PR DESCRIPTION
Relates to | Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] `./test.bash` passes locally
- [ ] Appropriate changes to documentation are included in the PR
