### PR TITLE
fix (build): Refine Bazel .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Bazel
-bazel-*
+/bazel-bin
+/bazel-enola
+/bazel-out
+/bazel-testlogs
 
 # Gradle
 build/


### PR DESCRIPTION
Because as-is it was also ignoring e.g. a (new, upcoming separate change) tools/bazel-java-tool-chain/, which is pretty confusing.

Relates to #546.