### PR TITLE
Java from Bazel Toolchain

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -33,6 +33,7 @@ tab_width = 2
 [*.bash]
 indent_size = 2
 tab_width = 2
+max_line_length = unset
 
 [*.css]
 indent_size = 2

--- a/enola
+++ b/enola
@@ -35,12 +35,15 @@ else
   exit 255
 fi
 
+source "$ROOT"/tools/bazel-java-tool-chain/bazel-java-tool-chain.bash
+JAVA=$(java_binary)
+
 cd "$ROOT"
 LOG=$(mktemp)
 if "$BZL" build --color=yes //cli:enola_deploy.jar >"$LOG" 2>&1 ; then
   rm "$LOG"
   # TODO Integrate this with (use) tools/distro/build.sh instead of launching it like this
-  cd "$CWD" && java --enable-preview -jar "$ROOT"/bazel-bin/cli/enola_deploy.jar "$@"
+  cd "$CWD" && $JAVA --enable-preview -jar "$ROOT"/bazel-bin/cli/enola_deploy.jar "$@"
 else
   cat "$LOG" && echo >&2 && echo >&2
   rm "$LOG"

--- a/tools/bazel-java-tool-chain/bazel-java-tool-chain.bash
+++ b/tools/bazel-java-tool-chain/bazel-java-tool-chain.bash
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2023-2024 The Enola <https://enola.dev> Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DIR=$(pwd)
+# https://unix.stackexchange.com/a/476710/103272
+OLDOPTS="$(set +o); set -${-//c}"
+trap cleanup EXIT
+set +euo pipefail
+function cleanup {
+  eval "${OLDOPTS}"
+  cd "$DIR" || exit 8
+  trap - EXIT
+}
+
+# This obtains the path to the JDK (its "Java toolchain") which Bazel downloaded.
+#
+# For background, see:
+#   * https://github.com/enola-dev/enola/issues/546
+#   * https://github.com/salesforce/bazel-eclipse/blob/888bcd333ac7bd4166fdb411562b74c2b54514d5/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/BaseProvisioningStrategy.java#L945-L960
+#   * https://stackoverflow.com/questions/78057833/how-to-query-bazel-for-the-absolute-jave-home-like-path-to-the-remote-jdk-of
+
+function java_binary {
+  local current_java_runtime
+
+  ROOT="$(realpath "$(dirname "${BASH_SOURCE[0]}"/)")"
+  cd "$ROOT" || exit 9
+
+  # Hide Bazel output, unlike it failed (same also in //enola)
+  LOG=$(mktemp)
+  if ! current_java_runtime="$(bazelisk cquery @bazel_tools//tools/jdk:current_java_runtime \
+    --output starlark --starlark:file "$ROOT"/bazel-java-tool-chain.bzl 2>"$LOG")"; then
+    cat "$LOG"
+    rm "$LOG"
+    exit 7
+  else
+    rm "$LOG"
+  fi
+
+  LOG=$(mktemp)
+  if ! output_base="$(bazel info output_base 2>"$LOG")"; then
+    cat "$LOG"
+    rm "$LOG"
+    exit 7
+  else
+    rm "$LOG"
+  fi
+
+  echo "$output_base/$current_java_runtime/bin/java"
+}

--- a/tools/bazel-java-tool-chain/bazel-java-tool-chain.bzl
+++ b/tools/bazel-java-tool-chain/bazel-java-tool-chain.bzl
@@ -1,0 +1,22 @@
+"""This module contains a helper function to extract the location of the JDK."""
+
+def format(target):
+    """Returns current_java_runtime.
+
+    Args:
+        target: Bazel Target
+
+    Returns:
+        Path to JDK, e.g. "external/remotejdk21_linux".
+    """
+
+    # See https://github.com/enola-dev/enola/issues/546
+    runtime_infos = {k: v for k, v in providers(target).items() if k.endswith("JavaRuntimeInfo")}
+
+    if len(runtime_infos) == 1:
+        java_runtime_info = runtime_infos.values()[0]
+
+        # https://bazel.build/rules/lib/providers/JavaRuntimeInfo
+        return java_runtime_info.java_home
+
+    fail("Unable to obtain JavaRuntimeInfo.")

--- a/tools/bazel-java-tool-chain/test.bash
+++ b/tools/bazel-java-tool-chain/test.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2023-2024 The Enola <https://enola.dev> Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+CWD=$(pwd)
+ROOT="$(realpath "$(dirname "$0")")"
+cd /tmp
+
+# shellcheck disable=SC1091
+source "$ROOT"/bazel-java-tool-chain.bash
+
+java_binary
+
+cd "$CWD"

--- a/web/ui/src/main/java/dev/enola/web/ui/ThingUI.java
+++ b/web/ui/src/main/java/dev/enola/web/ui/ThingUI.java
@@ -31,6 +31,9 @@ import java.util.Map;
 
 public class ThingUI {
 
+    // We intentionally don't use any template engine here; see e.g.
+    // https://blog.machinezoo.com/template-engines-broken for why.
+
     // See https://github.com/google/google-java-format/issues/1033 re. STR formatting :()
 
     // TODO Use Appendable-based approach, for better memory efficiency, and less String "trashing"


### PR DESCRIPTION
Relates to (and is initially fix for) #546.

But as-is, this makes `./enola` noticeable slower (because it invokes Bazel x2); I'll optimize it in a follow-up.

There is also some more clean-up possible based on this; that will come in #553, on another day.