### PR TITLE
fix   (ide): Bump google-java-formatter from 1.20.0 to 1.21.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -112,7 +112,7 @@ repos:
     hooks:
       - id: pretty-format-java
         # Keep this version in sync with the same version in .vscode/settings.json
-        args: [--autofix, --aosp, --google-java-formatter-version=1.20.0]
+        args: [--autofix, --aosp, --google-java-formatter-version=1.21.0]
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.12.1

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -71,9 +71,7 @@
   "java.format.settings.google.extra": "--aosp", // For 4 instead of 2 spaces!
   // Keep this version in sync with the same version in .pre-commit-config.yaml
   // NB: Changes to this are only taken into account on start-up, so need to restart.
-  "java.format.settings.google.version": "1.20.0",
-  // TODO Remove when https://github.com/google/google-java-format/issues/1072 is fixed:
-  "java.format.settings.google.mode": "jar-file",
+  "java.format.settings.google.version": "1.21.0",
   // TODO https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3050
   "java.compile.nullAnalysis.mode": "automatic",
   "java.completion.importOrder": ["#", "", "javax", "java"], //# is static

--- a/cli/src/test/java/dev/enola/cli/EnolaTest.java
+++ b/cli/src/test/java/dev/enola/cli/EnolaTest.java
@@ -126,11 +126,11 @@ public class EnolaTest {
                 .out()
                 .startsWith(
                         """
-                            id {
-                              ns: "test"
-                              entity: "foobar"
-                              paths: "helo"
-                            """);
+                        id {
+                          ns: "test"
+                          entity: "foobar"
+                          paths: "helo"
+                        """);
     }
 
     @Test

--- a/common/common/src/test/java/dev/enola/common/io/resource/MarkdownResourceTest.java
+++ b/common/common/src/test/java/dev/enola/common/io/resource/MarkdownResourceTest.java
@@ -41,7 +41,7 @@ public class MarkdownResourceTest {
             ...
             -->
 
-                """;
+            """;
 
     String FRONTMATTER =
             """
@@ -51,11 +51,12 @@ public class MarkdownResourceTest {
 
             """;
 
-    String MD = """
+    String MD =
+            """
             # Thaw Blough!
 
             **It rocks...**
-                """;
+            """;
 
     @Test
     public void commentFrontmatterMarkdown() throws IOException {

--- a/core/impl/src/test/java/dev/enola/core/tbd/RosettaTest.java
+++ b/core/impl/src/test/java/dev/enola/core/tbd/RosettaTest.java
@@ -64,18 +64,18 @@ public class RosettaTest {
         var expectedOut =
                 StringResource.of(
                         """
-                            id:
-                              ns: demo
-                              entity: bar
-                              paths: [abc, def]
-                            related:
-                              one:
-                                ns: demo
-                                entity: baz
-                                paths: [uvw]
-                            link: {wiki:\
-                             'https://en.wikipedia.org/w/index.php?fulltext=Search&search=def'}
-                            """,
+                        id:
+                          ns: demo
+                          entity: bar
+                          paths: [abc, def]
+                        related:
+                          one:
+                            ns: demo
+                            entity: baz
+                            paths: [uvw]
+                        link: {wiki:\
+                         'https://en.wikipedia.org/w/index.php?fulltext=Search&search=def'}
+                        """,
                         YAML_UTF_8);
         assertThat(out.charSource().read()).isEqualTo(expectedOut.charSource().read());
     }


### PR DESCRIPTION
This fixes https://github.com/google/google-java-format/issues/1072.
