### PR TITLE
Fix ExecMD Markdown (EOF EOL) line break bug

### DIFF
--- a/java/dev/enola/common/markdown/exec/ExecMD.java
+++ b/java/dev/enola/common/markdown/exec/ExecMD.java
@@ -101,6 +101,7 @@ public class ExecMD {
             }
 
             exec(dir, preamble, command.toString(), outScript, outMD);
+            if (!endsWith(outMD, '\n')) outMD.append("\n");
             outMD.append("```\n");
         }
 
@@ -110,6 +111,10 @@ public class ExecMD {
         pair.markdown = outMD.toString();
         pair.script = outScript.toString();
         return pair;
+    }
+
+    private boolean endsWith(CharSequence cs, char trailing) {
+        return cs.charAt(cs.length() - 1) == trailing;
     }
 
     int exec(Path dir, String preamble, String command, Appendable script, Appendable md)

--- a/java/dev/enola/common/markdown/exec/ExecMDTest.java
+++ b/java/dev/enola/common/markdown/exec/ExecMDTest.java
@@ -31,30 +31,38 @@ public class ExecMDTest {
     private static final Path CWD = Path.of(".");
 
     @Test
-    public void testEcho() throws MarkdownProcessingException, IOException {
+    public void echo() throws MarkdownProcessingException, IOException {
         var r = new ExecMD().process(CWD, "# Test\n```bash\n$ echo hi\nIGNORED\n```");
         assertEquals("# Test\n```bash\n$ echo hi\nhi\n```\n", r.markdown);
         assertThat(r.script).contains("echo hi");
     }
 
     @Test
-    public void testFalse() throws MarkdownProcessingException, IOException {
+    public void isFalse() throws MarkdownProcessingException, IOException {
         var r = new ExecMD().process(CWD, "# Test\n```bash $?\n$ false\n```");
         assertEquals("# Test\n```bash\n$ false\n```\n", r.markdown);
         assertThat(r.script).contains("false");
     }
 
     @Test
-    public void testPreambleInit() throws MarkdownProcessingException, IOException {
+    public void preambleInit() throws MarkdownProcessingException, IOException {
         var r = new ExecMD().process(CWD, "# Test\n```bash MSG=hi\n$ echo $MSG\n```");
         assertEquals("# Test\n```bash\n$ echo $MSG\nhi\n```\n", r.markdown);
         assertThat(r.script).contains(":MSG=hi\necho $MSG");
     }
 
     @Test
-    public void testMultiline() throws MarkdownProcessingException, IOException {
+    public void multiline() throws MarkdownProcessingException, IOException {
         var r = new ExecMD().process(CWD, "```bash\n$ echo \\\n  Hi\n```");
         assertEquals("```bash\n$ echo \\\n  Hi\nHi\n```\n", r.markdown);
         assertThat(r.script).contains("echo \\\n  Hi");
+    }
+
+    @Test
+    public void eof_eol() throws MarkdownProcessingException, IOException {
+        var r = new ExecMD().process(CWD, "```bash\n$ echo -n \"hello, \" && echo -n world\n```");
+        assertEquals(
+                "```bash\n$ echo -n \"hello, \" && echo -n world\nhello, world\n```\n", r.markdown);
+        assertThat(r.script).contains("echo -n \"hello, \" && echo -n world");
     }
 }


### PR DESCRIPTION
This should fix the currently broken Markdown / HTML rendering e.g. on https://docs.enola.dev/use/canonicalize/.