### PR TITLE
Fix recently broken HTTP Web server

### DIFF
--- a/java/dev/enola/cli/CommandWithResourceProvider.java
+++ b/java/dev/enola/cli/CommandWithResourceProvider.java
@@ -102,7 +102,7 @@ public abstract class CommandWithResourceProvider implements CheckedRunnable {
         DatatypeRepository dtr = Datatypes.DTR;
         ctx.push(DatatypeRepository.class, dtr);
 
-        // TODO This must be configurable & dynamic...
+        // TODO This must be configurable & dynamic... but shouldn't be configured in package cli?
         var namespaceRepo = NamespaceRepositoryEnolaDefaults.INSTANCE;
         var namespaceConverter = new NamespaceConverterWithRepository(namespaceRepo);
         ctx.push(NamespaceConverter.class, namespaceConverter);

--- a/java/dev/enola/cli/ServerCommand.java
+++ b/java/dev/enola/cli/ServerCommand.java
@@ -17,6 +17,7 @@
  */
 package dev.enola.cli;
 
+import dev.enola.common.context.TLC;
 import dev.enola.core.grpc.EnolaGrpcServer;
 import dev.enola.core.meta.EntityKindRepository;
 import dev.enola.core.proto.EnolaServiceGrpc;
@@ -43,6 +44,15 @@ public class ServerCommand extends CommandWithModel {
 
     @Override
     protected void run(EntityKindRepository ekr, EnolaServiceGrpc.EnolaServiceBlockingStub service)
+            throws Exception {
+        try (var ctx = TLC.open()) {
+            setup(ctx);
+            runInContext(ekr, service);
+        }
+    }
+
+    private void runInContext(
+            EntityKindRepository ekr, EnolaServiceGrpc.EnolaServiceBlockingStub service)
             throws Exception {
         var out = spec.commandLine().getOut();
 

--- a/java/dev/enola/common/concurrent/BUILD
+++ b/java/dev/enola/common/concurrent/BUILD
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 load("@rules_java//java:defs.bzl", "java_library")
+load("//tools/bazel:junit.bzl", "junit_tests")
 
 java_library(
     name = "concurrent",
@@ -25,9 +26,20 @@ java_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//java/dev/enola/common",
+        "//java/dev/enola/common/context",
         "@maven//:com_google_errorprone_error_prone_annotations",
         "@maven//:com_google_guava_guava",
         "@maven//:org_jspecify_jspecify",
+        "@maven//:org_slf4j_slf4j_api",
+    ],
+)
+
+junit_tests(
+    name = "tests",
+    srcs = glob(["**/*Test.java"]),
+    deps = [
+        ":concurrent",
+        "//java/dev/enola/common/context",
         "@maven//:org_slf4j_slf4j_api",
     ],
 )

--- a/java/dev/enola/common/concurrent/Executors.java
+++ b/java/dev/enola/common/concurrent/Executors.java
@@ -22,6 +22,8 @@ import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
+import dev.enola.common.context.ContextAwareThreadFactory;
+
 import org.slf4j.Logger;
 
 import java.util.concurrent.ExecutorService;
@@ -31,9 +33,14 @@ import java.util.concurrent.TimeUnit;
 /**
  * Additional factory and utility methods for executors.
  *
- * <p>Use this instead of {@link java.util.concurrent.Executors}, because it ensures that the
- * returned Executor uses a {@link ThreadFactory} that is named, has a logging
- * UncaughtExceptionHandler, and returns (Guava's) ListenableFuture.
+ * <p>Use this instead of {@link java.util.concurrent.Executors}, because it ensures that:
+ *
+ * <ul>
+ *   <li></b>the {@link dev.enola.common.context.TLC} is correctly propagated</b>
+ *   <li>the returned Executor uses a {@link ThreadFactory} that is named,
+ *   <li>has a logging UncaughtExceptionHandler,
+ *   <li>returns (Guava's) ListenableFuture.
+ * </ul>
  *
  * @author Michael Vorburger.ch, originally for https://www.opendaylight.org
  */
@@ -63,8 +70,8 @@ public final class Executors {
      * Creates a single thread executor with a {@link ThreadFactory} that uses the provided prefix
      * for its thread names and logs uncaught exceptions with the specified {@link Logger}.
      *
-     * @param namePrefix Prefix for threads from this executor. For example, "rpc-pool", to create *
-     *     "rpc-pool-1/2/3" named threads. Note that this is a prefix, not a format, * so you pass
+     * @param namePrefix Prefix for threads from this executor. For example, "rpc-pool", to create
+     *     "rpc-pool-1/2/3" named threads. Note that this is a prefix, not a format, so you pass
      *     just "rpc-pool" instead of e.g. "rpc-pool-%d".
      * @param logger Logger used to log uncaught exceptions from new threads created from this.
      * @see java.util.concurrent.Executors#newSingleThreadExecutor()
@@ -129,7 +136,8 @@ public final class Executors {
                         .setUncaughtExceptionHandler(
                                 dev.enola.common.concurrent.LoggingThreadUncaughtExceptionHandler
                                         .toLogger(logger))
-                        .setDaemon(true);
+                        .setDaemon(true)
+                        .setThreadFactory(new ContextAwareThreadFactory());
         // priority.ifPresent(guavaBuilder::setPriority);
         logger.info("ThreadFactory created: {}", namePrefix);
         return guavaBuilder.build();

--- a/java/dev/enola/common/concurrent/ExecutorsTest.java
+++ b/java/dev/enola/common/concurrent/ExecutorsTest.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2024 The Enola <https://enola.dev> Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.enola.common.concurrent;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import dev.enola.common.context.Context;
+import dev.enola.common.context.TLC;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ExecutorsTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExecutorsTest.class);
+
+    @Test
+    public void tlc() throws ExecutionException, InterruptedException {
+        try (var executor = Executors.newListeningSingleThreadExecutor("ExecutorsTest", LOG)) {
+            try (var ctx = TLC.open()) {
+                ctx.push(TestCtxKey.MAGIC, 123);
+
+                var atomic = new AtomicInteger();
+                Runnable runnable = () -> atomic.set(TLC.get(TestCtxKey.MAGIC));
+
+                executor.submit(runnable).get();
+
+                assertThat(atomic.get()).isEqualTo(123);
+            }
+        }
+    }
+
+    private enum TestCtxKey implements Context.Key<Integer> {
+        MAGIC
+    }
+}

--- a/java/dev/enola/common/context/ContextAwareThreadFactory.java
+++ b/java/dev/enola/common/context/ContextAwareThreadFactory.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2024 The Enola <https://enola.dev> Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.enola.common.context;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.concurrent.ThreadFactory;
+
+public final class ContextAwareThreadFactory implements ThreadFactory {
+
+    private final ThreadFactory delegate;
+
+    public ContextAwareThreadFactory() {
+        this(java.util.concurrent.Executors.defaultThreadFactory());
+    }
+
+    public ContextAwareThreadFactory(ThreadFactory delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Thread newThread(Runnable runnable) {
+        Context currentTLC = TLC.get();
+        // TODO rm: if (currentTLC == null) throw new IllegalStateException("No TLC found?!");
+        Thread thread = delegate.newThread(new RunnableWrapper(runnable, currentTLC));
+        return thread;
+    }
+
+    private static class RunnableWrapper implements Runnable {
+        private final Runnable delegate;
+        private final @Nullable Context outerContext;
+
+        public RunnableWrapper(Runnable delegate, @Nullable Context outerContext) {
+            this.delegate = delegate;
+            this.outerContext = outerContext;
+        }
+
+        @Override
+        public void run() {
+            Context currentTLC = TLC.get();
+            if (currentTLC != null)
+                throw new IllegalStateException(
+                        "New Thread should not have a TLC already?! " + currentTLC);
+            if (outerContext != null) TLC.setThreadLocalContext(outerContext);
+            delegate.run();
+        }
+    }
+}

--- a/java/dev/enola/common/context/ContextAwareThreadFactoryTest.java
+++ b/java/dev/enola/common/context/ContextAwareThreadFactoryTest.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2024 The Enola <https://enola.dev> Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.enola.common.context;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ContextAwareThreadFactoryTest {
+
+    @Test
+    public void wrap() throws InterruptedException {
+        var tf = new ContextAwareThreadFactory();
+        try (var ctx = TLC.open()) {
+            ctx.push(TestCtxKey.MAGIC, 123);
+
+            var atomic = new AtomicInteger();
+            Runnable runnable = () -> atomic.set(TLC.get(TestCtxKey.MAGIC));
+            var thread = tf.newThread(runnable);
+            thread.start();
+            thread.join();
+
+            assertThat(atomic.get()).isEqualTo(123);
+        }
+    }
+
+    private enum TestCtxKey implements Context.Key<Integer> {
+        MAGIC
+    }
+}

--- a/java/dev/enola/common/context/TLC.java
+++ b/java/dev/enola/common/context/TLC.java
@@ -47,8 +47,12 @@ public final class TLC {
         } else {
             next = new Context();
         }
-        threadLocalContext.set(next);
+        setThreadLocalContext(next);
         return next;
+    }
+
+    /* package local! */ static void setThreadLocalContext(Context context) {
+        threadLocalContext.set(context);
     }
 
     /**

--- a/java/dev/enola/web/BUILD
+++ b/java/dev/enola/web/BUILD
@@ -57,6 +57,7 @@ junit_tests(
     ],
     deps = [
         ":web",
+        "//java/dev/enola/common/context",
         "//java/dev/enola/common/io",
         "//java/dev/enola/common/protobuf",
         "//java/dev/enola/core",

--- a/java/dev/enola/web/BUILD
+++ b/java/dev/enola/web/BUILD
@@ -29,6 +29,7 @@ java_library(
     resources = glob(["resources/**/*"]),
     visibility = ["//:__subpackages__"],
     deps = [
+        "//java/dev/enola/common/concurrent",
         "//java/dev/enola/common/convert",
         "//java/dev/enola/common/io",
         "//java/dev/enola/common/protobuf",

--- a/java/dev/enola/web/SunServer.java
+++ b/java/dev/enola/web/SunServer.java
@@ -30,6 +30,7 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 
+import dev.enola.common.concurrent.Executors;
 import dev.enola.common.io.resource.ReadableResource;
 
 import org.slf4j.Logger;
@@ -39,15 +40,17 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.InetSocketAddress;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 
 /** {@link WebServer} API implementation using {@link HttpServer} from com.sun. */
 public class SunServer implements WebServer {
 
     private static final Logger LOG = LoggerFactory.getLogger(SunServer.class);
 
-    private static final Executor SERVER_EXECUTOR = Executors.newCachedThreadPool();
-    private static final Executor HANDLER_EXECUTOR = Executors.newSingleThreadExecutor();
+    private static final Executor SERVER_EXECUTOR =
+            Executors.newListeningCachedThreadPool("Server", LOG);
+
+    private static final Executor HANDLER_EXECUTOR =
+            Executors.newListeningSingleThreadExecutor("Handler", LOG);
 
     private final HttpServer sun;
 

--- a/java/dev/enola/web/SunServer.java
+++ b/java/dev/enola/web/SunServer.java
@@ -47,10 +47,10 @@ public class SunServer implements WebServer {
     private static final Logger LOG = LoggerFactory.getLogger(SunServer.class);
 
     private static final Executor SERVER_EXECUTOR =
-            Executors.newListeningCachedThreadPool("Server", LOG);
+            Executors.newListeningCachedThreadPool("HttpServer", LOG);
 
     private static final Executor HANDLER_EXECUTOR =
-            Executors.newListeningSingleThreadExecutor("Handler", LOG);
+            Executors.newListeningSingleThreadExecutor("HttpHandler", LOG);
 
     private final HttpServer sun;
 

--- a/java/dev/enola/web/SunServerTest.java
+++ b/java/dev/enola/web/SunServerTest.java
@@ -23,6 +23,8 @@ import static com.google.common.util.concurrent.Futures.immediateFuture;
 
 import com.google.common.net.MediaType;
 
+import dev.enola.common.context.Context;
+import dev.enola.common.context.TLC;
 import dev.enola.common.io.resource.ResourceProviders;
 import dev.enola.common.io.resource.StringResource;
 
@@ -52,38 +54,55 @@ public class SunServerTest {
                     throw new IllegalArgumentException("oink");
                 });
 
+        server.register(
+                "/context",
+                uri -> immediateFuture(StringResource.of(TLC.get(TestCtxKey.MAGIC).toString())));
+
         server.start();
         return server;
     }
 
     @Test
     public void testServer() throws IOException {
-        try (var server = start()) {
-            var prefix = "http://localhost:" + server.getInetAddress().getPort();
-            var rp = new ResourceProviders();
 
-            // IPv6 NOK :( var uri = URI.create("http://" + server.getInetAddress() + "/hello");
-            var uri1 = URI.create(prefix + "/hello");
-            var response1 = rp.getResource(uri1);
-            assertThat(response1.mediaType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
-            assertThat(response1.charSource().read()).isEqualTo("hello, world");
+        try (var ctx = TLC.open()) {
+            ctx.push(TestCtxKey.MAGIC, 123);
 
-            var uri2 = URI.create(prefix + "/abc/xyz/hello.txt");
-            var response2 = rp.getResource(uri2);
-            assertThat(response2.mediaType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
-            assertThat(response2.charSource().read()).isEqualTo("hi, you\n");
+            try (var server = start()) {
+                var prefix = "http://localhost:" + server.getInetAddress().getPort();
+                var rp = new ResourceProviders();
 
-            var error1 = URI.create(prefix + "/error1");
-            Assert.assertThrows(IllegalArgumentException.class, () -> rp.getResource(error1));
-            // var errorResponse1 = rp.getResource(error1);
-            // Assert.assertThrows(IOException.class, () -> errorResponse1.charSource().read());
+                // IPv6 NOK :( var uri = URI.create("http://" + server.getInetAddress() + "/hello");
+                var uri1 = URI.create(prefix + "/hello");
+                var response1 = rp.getResource(uri1);
+                assertThat(response1.mediaType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+                assertThat(response1.charSource().read()).isEqualTo("hello, world");
 
-            var error2 = URI.create(prefix + "/error2");
-            Assert.assertThrows(IllegalArgumentException.class, () -> rp.getResource(error2));
-            // var errorResponse2 = rp.getResource(error2);
-            // Assert.assertThrows(IOException.class, () -> errorResponse2.charSource().read());
+                var contextURI = URI.create(prefix + "/context");
+                // TODO !?! var responseFromTLC = rp.getResource(contextURI);
+                // TODO !?! assertThat(responseFromTLC.charSource().read()).isEqualTo("123");
 
-            // TODO expect HTTP Error 500
+                var uri2 = URI.create(prefix + "/abc/xyz/hello.txt");
+                var response2 = rp.getResource(uri2);
+                assertThat(response2.mediaType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+                assertThat(response2.charSource().read()).isEqualTo("hi, you\n");
+
+                var error1 = URI.create(prefix + "/error1");
+                Assert.assertThrows(IllegalArgumentException.class, () -> rp.getResource(error1));
+                // var errorResponse1 = rp.getResource(error1);
+                // Assert.assertThrows(IOException.class, () -> errorResponse1.charSource().read());
+
+                var error2 = URI.create(prefix + "/error2");
+                Assert.assertThrows(IllegalArgumentException.class, () -> rp.getResource(error2));
+                // var errorResponse2 = rp.getResource(error2);
+                // Assert.assertThrows(IOException.class, () -> errorResponse2.charSource().read());
+
+                // TODO expect HTTP Error 500
+            }
         }
+    }
+
+    private enum TestCtxKey implements Context.Key<Integer> {
+        MAGIC
     }
 }

--- a/java/dev/enola/web/UiTest.java
+++ b/java/dev/enola/web/UiTest.java
@@ -56,6 +56,7 @@ public class UiTest {
     public void testUi() throws Exception {
         var addr = new InetSocketAddress(0);
         try (var server = new SunServer(addr)) {
+            // TODO Change this to use a "real" set-up; to detect e.g. broken wiring issues
             var rp = new ResourceProviders();
             var ekr = new EntityKindRepository();
             var esp = new EnolaServiceProvider(ekr, rp);


### PR DESCRIPTION
This doesn't actually really fix it yet; un-commenting the `TODO !?!` in the `SunServerTest` reproduces the problem.

The `ContextAwareThreadFactoryTest` and then the `ExecutorsTest` "prove" (hopefully) that the "underlying plumbing" is fixed...

~~... but I cannot quite figure out why this new "propagation" does now not just also work as-is in the Web Server?~~

... but the `com.sun.net.httpserver.HttpServer` invokes my `ContextAwareThreadFactory#newThread` on its `HTTP-Dispatcher` thread, and THAT one was not created by our _special_ (propagating) new `ThreadFactory`, that's why it's still not finding it! 😿  How/where do you set the `Executor` or `ThreadFactory` for THAT?!

It's [because of this](https://github.com/openjdk/jdk21u-dev/blob/cd5ac19b4966741904314d42c6ee30ac1d9e0ca9/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java#L189)! Aw, fuck JDK... 

I'm going to already merge this as-is, for now; and follow-up with #849.