### PR TITLE
feat (core): /gexf?q=enola:/inline now returns GEXF (for #502)

### DIFF
--- a/docs/use/canonicalize/index.md
+++ b/docs/use/canonicalize/index.md
@@ -36,7 +36,7 @@ It also has an application in [cryptography](https://github.com/enola-dev/enola/
 `enola canonicalize` for RDF order statements by predicate IRI, for example:
 
 ```bash cd ../.././..
-$ ./enola -v canonicalize --load=test/picasso.ttl
+$ ./enola canonicalize --load=test/picasso.ttl
 ...
 ```
 

--- a/java/dev/enola/web/ThingsConverterWrapperHandler.java
+++ b/java/dev/enola/web/ThingsConverterWrapperHandler.java
@@ -45,6 +45,7 @@ class ThingsConverterWrapperHandler implements WebHandler {
     @Override
     public ListenableFuture<ReadableResource> handle(URI uri) {
         var query = URIs.getQueryMap(uri).get("q");
+        if (query == null) throw new IllegalArgumentException("Missing ?q=");
         if (!query.equals(ListThingService.ENOLA_ROOT_LIST_THINGS))
             throw new IllegalArgumentException(
                     "Currently (TODO) only supports ?q="

--- a/java/dev/enola/web/UI.java
+++ b/java/dev/enola/web/UI.java
@@ -41,6 +41,7 @@ import dev.enola.core.proto.GetFileDescriptorSetRequest;
 import dev.enola.core.proto.GetThingRequest;
 import dev.enola.core.view.EnolaMessages;
 import dev.enola.thing.gen.LinkTransformer;
+import dev.enola.thing.gen.gexf.GexfGenerator;
 import dev.enola.thing.gen.visjs.VisJsTimelineGenerator;
 import dev.enola.thing.message.ProtoThingMetadataProvider;
 import dev.enola.thing.metadata.ThingMetadataProvider;
@@ -66,6 +67,7 @@ public class UI implements WebHandler {
     private final LinkTransformer linkTransformer = new UiLinkTransformer();
     private final ThingUI thingUI;
     private final ThingsConverterWrapperHandler timelineHandler;
+    private final ThingsConverterWrapperHandler gexfHandler;
     private ProtoIO protoIO;
 
     public UI(EnolaServiceBlockingStub service, ThingMetadataProvider metadataProvider)
@@ -86,12 +88,16 @@ public class UI implements WebHandler {
                 new ThingsConverterWrapperHandler(
                         thingRepository,
                         new VisJsTimelineGenerator(metadataProvider, linkTransformer));
+        gexfHandler =
+                new ThingsConverterWrapperHandler(
+                        thingRepository, new GexfGenerator(metadataProvider));
     }
 
     public void register(WebHandlers handlers) {
         handlers.register("/ui/static/", new StaticWebHandler("/ui/static/", "static"));
         handlers.register("/ui", this);
         handlers.register("/timeline", timelineHandler);
+        handlers.register("/gexf", gexfHandler);
         // TODO Create HTML page “frame” from template, with body from another template
         handlers.register("", uri -> immediateFuture(FOUR_O_FOUR));
     }


### PR DESCRIPTION
Relates to [#502](https://github.com/enola-dev/enola/issues/502#issuecomment-2379602458):

```sh
./enola server --load="docs/models/example.org/*.ttl" --httpPort=8080
```

<http://[::]:8080/gexf?q=enola:/inline>

now returns https://docs.enola.dev/use/rosetta/#gexf

@edewit FYI