### PR TITLE
Flush the `Writer` during `close()`.

### DIFF
--- a/java/dev/enola/common/io/resource/WriterCharSink.java
+++ b/java/dev/enola/common/io/resource/WriterCharSink.java
@@ -48,7 +48,9 @@ class WriterCharSink extends CharSink {
 
         @Override
         public void close() throws IOException {
-            // IGNORE!
+            // Do not close! But do flush in case the writer has a buffer that needs to be sent to
+            // an underlying OutputStream.
+            flush();
         }
     }
 }


### PR DESCRIPTION
This shouldn't matter for the current usage, which wraps `System.out`,
which I assume will at minimum get auto-flushed at process exit. But it
can matter for general usage, in which the `Writer` might be holding on
to some buffered data that needs to be flushed.

(You can see an example of trouble with a similar class inside Google in
cl/688193452. There is arguably more wrong there than just the lack of a
`flush()` call, but `flush()` at least defends against one specific
problem.)
