### PR TITLE
Fix ThingMediaTypesTest

### DIFF
--- a/java/dev/enola/cli/DetectCommand.java
+++ b/java/dev/enola/cli/DetectCommand.java
@@ -19,7 +19,6 @@ package dev.enola.cli;
 
 import dev.enola.common.context.TLC;
 import dev.enola.common.io.iri.URIs;
-import dev.enola.common.io.mediatype.MediaTypeProviders;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -32,8 +31,8 @@ import java.nio.file.Paths;
         name = "detect",
         description =
                 "Provides information about the media type detected for a given URL.\n"
-                        + "This works both for local files (based on extension), and remote HTTP (based"
-                        + " on headers).")
+                    + "This works both for local files (based on extension), and remote HTTP (based"
+                    + " on headers).")
 public class DetectCommand extends CommandWithResourceProvider {
 
     @Spec CommandSpec spec;
@@ -46,13 +45,7 @@ public class DetectCommand extends CommandWithResourceProvider {
         super.run();
         try (var ctx = TLC.open().push(URIs.ContextKeys.BASE, Paths.get("").toUri())) {
             var resource = rp.getResource(URIs.parse(iri));
-            // TODO This seems *WRONG* ... here, use ONLY mediaType(), NOT MediaTypeProviders?
-            var mediaType =
-                    MediaTypeProviders.SINGLETON
-                            .get()
-                            .detect(resource)
-                            .orElse(resource.mediaType());
-
+            var mediaType = resource.mediaType();
             var pw = spec.commandLine().getOut();
             pw.println(mediaType);
         }

--- a/java/dev/enola/cli/DetectCommand.java
+++ b/java/dev/enola/cli/DetectCommand.java
@@ -32,8 +32,8 @@ import java.nio.file.Paths;
         name = "detect",
         description =
                 "Provides information about the media type detected for a given URL.\n"
-                    + "This works both for local files (based on extension), and remote HTTP (based"
-                    + " on headers).")
+                        + "This works both for local files (based on extension), and remote HTTP (based"
+                        + " on headers).")
 public class DetectCommand extends CommandWithResourceProvider {
 
     @Spec CommandSpec spec;
@@ -46,6 +46,7 @@ public class DetectCommand extends CommandWithResourceProvider {
         super.run();
         try (var ctx = TLC.open().push(URIs.ContextKeys.BASE, Paths.get("").toUri())) {
             var resource = rp.getResource(URIs.parse(iri));
+            // TODO This seems *WRONG* ... here, use ONLY mediaType(), NOT MediaTypeProviders?
             var mediaType =
                     MediaTypeProviders.SINGLETON
                             .get()

--- a/java/dev/enola/common/io/mediatype/MediaTypeProvider.java
+++ b/java/dev/enola/common/io/mediatype/MediaTypeProvider.java
@@ -63,8 +63,9 @@ public interface MediaTypeProvider extends ResourceMediaTypeDetector {
 
         if (mediaTypes.contains(original)) return original;
 
-        // TODO It's kinda wrong that this uses IMediaTypeProviders.CTX; it would be clearer if
-        // it only ever used itself. But requires moving normalize() from MediaTypeProviders to...
+        // TODO It's kinda wrong that this uses MediaTypeProviders.SINGLETON; it would be clearer if
+        // it only ever used itself. But that requires moving normalize() from MediaTypeProviders
+        // to...
         // where? Another ABC?! Urgh.
         var normalized = MediaTypeProviders.SINGLETON.get().normalize(original);
         if (!normalized.equals(original)) return normalized;

--- a/java/dev/enola/common/io/mediatype/MediaTypeProvider.java
+++ b/java/dev/enola/common/io/mediatype/MediaTypeProvider.java
@@ -65,8 +65,7 @@ public interface MediaTypeProvider extends ResourceMediaTypeDetector {
 
         // TODO It's kinda wrong that this uses MediaTypeProviders.SINGLETON; it would be clearer if
         // it only ever used itself. But that requires moving normalize() from MediaTypeProviders
-        // to...
-        // where? Another ABC?! Urgh.
+        // to... where? Another ABC?! Urgh.
         var normalized = MediaTypeProviders.SINGLETON.get().normalize(original);
         if (!normalized.equals(original)) return normalized;
 

--- a/java/dev/enola/common/io/mediatype/MediaTypeProviders.java
+++ b/java/dev/enola/common/io/mediatype/MediaTypeProviders.java
@@ -26,8 +26,9 @@ import dev.enola.common.context.Singleton;
 import java.util.*;
 
 /**
- * Aggregates other {@link MediaTypeProvider}s, either from an explicit list provided to
- * constructor, or found via service discovery. Typically used via {@link #SINGLETON}.
+ * Aggregates other {@link MediaTypeProvider}s, from an explicit list provided to constructor. (This
+ * intentionally does NOT use {@link ServiceLoader}; reasons include requiring a specific priority
+ * order.) Typically used via {@link #SINGLETON}.
  */
 public class MediaTypeProviders implements MediaTypeProvider {
 

--- a/java/dev/enola/common/io/mediatype/StandardMediaTypes.java
+++ b/java/dev/enola/common/io/mediatype/StandardMediaTypes.java
@@ -26,6 +26,7 @@ public class StandardMediaTypes implements MediaTypeProvider {
     @Override
     public Multimap<String, MediaType> extensionsToTypes() {
         return ImmutableMultimap.of(
+                ".txt", MediaType.PLAIN_TEXT_UTF_8,
                 ".html", MediaType.HTML_UTF_8,
                 ".json", MediaType.JSON_UTF_8,
                 ".css", MediaType.CSS_UTF_8,

--- a/java/dev/enola/common/io/resource/ClasspathResourceTest.java
+++ b/java/dev/enola/common/io/resource/ClasspathResourceTest.java
@@ -121,7 +121,7 @@ public class ClasspathResourceTest {
                 MediaType.create("text", "markdown").withCharset(UTF_8),
                 Optional.of(UTF_8),
                 md);
-        var resource = new UrlResource(Resources.getResource("test.md"), UTF_8);
+        var resource = new UrlResource(Resources.getResource("test.md"));
         assertThat(resource.charSource().read()).isEqualTo(md);
     }
 

--- a/java/dev/enola/common/io/resource/FileResourceTest.java
+++ b/java/dev/enola/common/io/resource/FileResourceTest.java
@@ -31,6 +31,7 @@ import com.google.common.net.MediaType;
 
 import dev.enola.common.context.testlib.SingletonRule;
 import dev.enola.common.io.mediatype.MediaTypeProviders;
+import dev.enola.common.io.mediatype.StandardMediaTypes;
 import dev.enola.common.io.mediatype.YamlMediaType;
 
 import org.junit.Ignore;
@@ -48,7 +49,8 @@ import java.nio.file.Path;
 
 public class FileResourceTest {
 
-    public @Rule SingletonRule r = $(MediaTypeProviders.set(new YamlMediaType()));
+    public @Rule SingletonRule r =
+            $(MediaTypeProviders.set(new YamlMediaType(), new StandardMediaTypes()));
 
     // ResourceProvidersTest has more, notably coverage for relative file URIs
 

--- a/java/dev/enola/common/io/resource/MediaTypeDetector.java
+++ b/java/dev/enola/common/io/resource/MediaTypeDetector.java
@@ -73,7 +73,7 @@ class MediaTypeDetector {
      */
     MediaType detect(URI uri, ByteSource byteSource) {
         var mediaTypeCharset = URIs.getMediaTypeAndCharset(uri);
-        var detected = detect(mediaTypeCharset.mediaType(), mediaTypeCharset.charset(), uri);
+        var detected = detect(mediaTypeCharset.mediaType(), mediaTypeCharset.charset());
         detected = detectCharsetAndMediaType(uri, byteSource, detected);
         return detected;
     }
@@ -144,11 +144,7 @@ class MediaTypeDetector {
         return mediaType;
     }
 
-    // This is currently still used by both UrlResource & OkHttpResource (and MediaTypeDetectorTest)
-    // but this is conceptually the same as the overwrite(URI uri, MediaType originalMediaType)
-    // TODO Switch OkHttpResource to use that instead
-    // TODO Make private (or inline and remove)
-    MediaType detect(@Nullable String contentType, @Nullable String contentEncoding, URI uri) {
+    private MediaType detect(@Nullable String contentType, @Nullable String contentEncoding) {
         MediaType mediaType = null;
         if (contentType != null) {
             mediaType = MediaTypes.parse(contentType);

--- a/java/dev/enola/common/io/resource/MediaTypeDetector.java
+++ b/java/dev/enola/common/io/resource/MediaTypeDetector.java
@@ -123,7 +123,6 @@ class MediaTypeDetector {
     // This is currently still used by both UrlResource & OkHttpResource (and MediaTypeDetectorTest)
     // but this is conceptually the same as the overwrite(URI uri, MediaType originalMediaType)
     // TODO Switch UrlResource & OkHttpResource to use that instead
-    // TODO Switch MediaTypeDetectorTest to use that instead
     // TODO Make private (or inline and remove)
     MediaType detect(@Nullable String contentType, @Nullable String contentEncoding, URI uri) {
         MediaType mediaType = null;

--- a/java/dev/enola/common/io/resource/MediaTypeDetector.java
+++ b/java/dev/enola/common/io/resource/MediaTypeDetector.java
@@ -50,8 +50,8 @@ import java.util.stream.Collectors;
  * <p>This class is intentionally package private, and should stay so; this is NOT for {@link
  * Resource} API users (who would just use {@link AbstractResource#mediaType()}); it's only used by
  * *Resource SPI implementations. (Which technically makes it impossible to {easily} write *Resource
- * implementations outside of this package; but with the current mono-repo architecture, that's just
- * fine.)
+ * implementations which do not extend BaseResource outside of this package; but with the current
+ * mono-repo architecture, that's just fine.)
  */
 class MediaTypeDetector {
     // NB: This class should *NEVER* implement MediaTypeProvider - that's a separate concern!
@@ -125,7 +125,7 @@ class MediaTypeDetector {
     MediaType detect(URI uri, ByteSource byteSource) {
         var mediaTypeCharset = URIs.getMediaTypeAndCharset(uri);
         var detected = detect(mediaTypeCharset.mediaType(), mediaTypeCharset.charset(), uri);
-        detected = detectCharset(uri, byteSource, detected);
+        detected = detectCharsetAndMediaType(uri, byteSource, detected);
         return detected;
     }
 
@@ -147,13 +147,14 @@ class MediaTypeDetector {
             if (!mediaType.charset().isPresent() && originalMediaType.charset().isPresent()) {
                 mediaType = mediaType.withCharset(originalMediaType.charset().get());
             } else {
-                mediaType = detectCharset(uri, ByteSource.empty(), mediaType);
+                mediaType = detectCharsetAndMediaType(uri, ByteSource.empty(), mediaType);
             }
         }
         return mediaType;
     }
 
-    private MediaType detectCharset(URI uri, ByteSource byteSource, MediaType detected) {
+    private MediaType detectCharsetAndMediaType(
+            URI uri, ByteSource byteSource, MediaType detected) {
         if (!detected.charset().isPresent()) {
             // TODO Make YAML just 1 of many Charset detectors...
             YamlMediaType rcd = new YamlMediaType();

--- a/java/dev/enola/common/io/resource/MediaTypeDetector.java
+++ b/java/dev/enola/common/io/resource/MediaTypeDetector.java
@@ -31,9 +31,7 @@ import org.jspecify.annotations.Nullable;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.spi.FileSystemProvider;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Utility for detecting a (better) {@link MediaType} for a Resource.
@@ -68,12 +66,6 @@ class MediaTypeDetector {
                 || IGNORE.contains(mediaTypeWithoutParameters)
                 || DEFAULT.equals(mediaTypeWithoutParameters);
     }
-
-    private static final Set<String> fileSystemProviderSchemes =
-            FileSystemProvider.installedProviders().stream()
-                    .map(p -> p.getScheme().toLowerCase())
-                    .filter(scheme -> !"jar".equals(scheme))
-                    .collect(Collectors.toSet());
 
     /**
      * This is called by Resource* implementation constructors, typically via {@link BaseResource},

--- a/java/dev/enola/common/io/resource/MediaTypeDetectorTest.java
+++ b/java/dev/enola/common/io/resource/MediaTypeDetectorTest.java
@@ -30,10 +30,7 @@ import static java.net.URI.create;
 import com.google.common.net.MediaType;
 
 import dev.enola.common.context.testlib.SingletonRule;
-import dev.enola.common.io.mediatype.MediaTypeProviders;
-import dev.enola.common.io.mediatype.MediaTypesTest;
-import dev.enola.common.io.mediatype.TestMediaType;
-import dev.enola.common.io.mediatype.YamlMediaType;
+import dev.enola.common.io.mediatype.*;
 import dev.enola.common.protobuf.ProtobufMediaTypes;
 
 import org.junit.Rule;
@@ -49,7 +46,10 @@ public class MediaTypeDetectorTest {
     public @Rule SingletonRule r =
             $(
                     MediaTypeProviders.set(
-                            new YamlMediaType(), new ProtobufMediaTypes(), new TestMediaType()));
+                            new YamlMediaType(),
+                            new ProtobufMediaTypes(),
+                            new TestMediaType(),
+                            new StandardMediaTypes()));
 
     MediaTypeDetector md = new MediaTypeDetector();
 
@@ -68,20 +68,27 @@ public class MediaTypeDetectorTest {
         assertThat(md.detect("application/octet-stream", null, create("hello.txt")))
                 .isEqualTo(OCTET_STREAM);
 
-        assertThat(md.detect(null, null, new File("hello.txt").toURI()))
-                .isEqualTo(PLAIN_TEXT_UTF_8);
-        assertThat(md.detect(null, null, new File("hello.json").toURI())).isEqualTo(JSON_UTF_8);
-
         assertThat(md.detect(null, null, create("bad-URI-without-scheme")))
                 .isEqualTo(MediaType.OCTET_STREAM);
     }
 
-    // TODO Rewrite all of above in this new style (to test the public API, instead of the
-    // implementation)
+    // TODO Rewrite all of above in this new style (to test the public API, instead implementation)
 
     @Test
     public void emptyOctetStream() {
         assertThat(EmptyResource.INSTANCE.mediaType()).isEqualTo(OCTET_STREAM);
+    }
+
+    @Test
+    public void testTXT() {
+        var r = new EmptyResource(create("whatever:hello.txt"));
+        assertThat(r.mediaType()).isEqualTo(PLAIN_TEXT_UTF_8);
+    }
+
+    @Test
+    public void testJSON() {
+        var r = new EmptyResource(create("whatever:hello.json"));
+        assertThat(r.mediaType()).isEqualTo(JSON_UTF_8);
     }
 
     @Test // Test that TestMediaTypes was correctly registered

--- a/java/dev/enola/common/io/resource/OkHttpResourceTest.java
+++ b/java/dev/enola/common/io/resource/OkHttpResourceTest.java
@@ -21,6 +21,8 @@ import static com.google.common.truth.Truth.assertThat;
 
 import static dev.enola.common.context.testlib.SingletonRule.$;
 
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+
 import com.google.common.net.MediaType;
 
 import dev.enola.common.context.testlib.SingletonRule;
@@ -42,7 +44,8 @@ public class OkHttpResourceTest {
     public void google() throws IOException {
         var r = new OkHttpResource("http://www.google.com");
         assertThat(r.charSource().read()).ignoringCase().contains("<!doctype html>");
-        assertThat(r.mediaType()).isEqualTo(MediaType.HTML_UTF_8);
+        // TODO Debug where the "iso-8859-1" here came from... it probably really should be UTF-8?!
+        assertThat(r.mediaType()).isEqualTo(MediaType.HTML_UTF_8.withCharset(ISO_8859_1));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/java/dev/enola/common/io/resource/ResourceProvidersTest.java
+++ b/java/dev/enola/common/io/resource/ResourceProvidersTest.java
@@ -31,6 +31,7 @@ import dev.enola.common.context.TLC;
 import dev.enola.common.context.testlib.SingletonRule;
 import dev.enola.common.io.iri.URIs;
 import dev.enola.common.io.mediatype.MediaTypeProviders;
+import dev.enola.common.io.mediatype.StandardMediaTypes;
 import dev.enola.common.io.mediatype.YamlMediaType;
 
 import org.junit.Rule;
@@ -45,7 +46,8 @@ import java.nio.file.Paths;
 
 public class ResourceProvidersTest {
 
-    public @Rule SingletonRule r = $(MediaTypeProviders.set(new YamlMediaType()));
+    public @Rule SingletonRule r =
+            $(MediaTypeProviders.set(new YamlMediaType(), new StandardMediaTypes()));
 
     private static final byte[] BYTES = new byte[] {1, 2, 3};
 

--- a/java/dev/enola/common/io/resource/UrlResource.java
+++ b/java/dev/enola/common/io/resource/UrlResource.java
@@ -24,7 +24,6 @@ import com.google.common.net.MediaType;
 
 import dev.enola.common.io.iri.URIs;
 
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,11 +98,11 @@ public class UrlResource extends BaseResource implements ReadableResource {
     }
 
     public UrlResource(URI uri, URL url) {
-        this(uri, url, mediaType(url, null));
+        this(uri, url, mediaType(url));
     }
 
     public UrlResource(URL url) {
-        this(URIs.create(url), url, mediaType(url, null));
+        this(URIs.create(url), url, mediaType(url));
     }
 
     public UrlResource(URL url, MediaType mediaType) {
@@ -111,13 +110,7 @@ public class UrlResource extends BaseResource implements ReadableResource {
         this.url = url;
     }
 
-    @Deprecated // TODO Remove, as un-used and pointless? Review Test Coverage #1st...
-    public UrlResource(URL url, Charset charset) {
-        super(URIs.create(url), mediaType(url, charset));
-        this.url = url;
-    }
-
-    private static MediaType mediaType(URL url, @Nullable Charset charset) {
+    private static MediaType mediaType(URL url) {
         // This is slow - but more correct; see https://www.baeldung.com/java-file-mime-type
         URLConnection c = null;
         try {
@@ -127,13 +120,6 @@ public class UrlResource extends BaseResource implements ReadableResource {
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options ?
             var contentTypeFromServer = c.getContentType();
             var encodingFromServer = c.getContentEncoding();
-
-            // TODO If encodingFromServer == null, try extracting from contentTypeFromServer
-            // https://stackoverflow.com/questions/3934251/urlconnection-does-not-get-the-charset
-
-            if (encodingFromServer == null && charset != null) {
-                encodingFromServer = charset.name();
-            }
 
             var mediaTypeFromServer = MediaType.parse(contentTypeFromServer);
             if (encodingFromServer != null) {

--- a/java/dev/enola/format/tika/TikaMediaTypeProviderTest.java
+++ b/java/dev/enola/format/tika/TikaMediaTypeProviderTest.java
@@ -22,6 +22,8 @@ import static com.google.common.truth.Truth.assertThat;
 
 import static dev.enola.common.context.testlib.SingletonRule.$;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.google.common.net.MediaType;
 
 import dev.enola.common.context.testlib.SingletonRule;
@@ -49,7 +51,7 @@ public class TikaMediaTypeProviderTest {
     @Test
     public void detectCBL() {
         var r = new FileResource(URI.create("file:///test.CBL"));
-        assertThat(r.mediaType()).isEqualTo(MediaType.parse("text/x-cobol"));
+        assertThat(r.mediaType()).isEqualTo(MediaType.parse("text/x-cobol").withCharset(UTF_8));
     }
 
     @Test

--- a/java/dev/enola/thing/gen/markdown/MarkdownSiteGeneratorTest.java
+++ b/java/dev/enola/thing/gen/markdown/MarkdownSiteGeneratorTest.java
@@ -29,7 +29,9 @@ import dev.enola.common.context.testlib.TestTLCRule;
 import dev.enola.common.io.iri.namespace.NamespaceConverter;
 import dev.enola.common.io.iri.namespace.NamespaceConverterWithRepository;
 import dev.enola.common.io.iri.namespace.NamespaceRepositoryEnolaDefaults;
+import dev.enola.common.io.mediatype.MarkdownMediaTypes;
 import dev.enola.common.io.mediatype.MediaTypeProviders;
+import dev.enola.common.io.mediatype.StandardMediaTypes;
 import dev.enola.common.io.resource.ClasspathResource;
 import dev.enola.common.io.resource.ReadableResource;
 import dev.enola.common.io.resource.ResourceProvider;
@@ -41,6 +43,7 @@ import dev.enola.rdf.io.RdfMediaTypes;
 import dev.enola.rdf.io.RdfReaderConverter;
 import dev.enola.rdf.proto.RdfProtoThingsConverter;
 import dev.enola.thing.gen.gexf.GexfMediaType;
+import dev.enola.thing.gen.graphviz.GraphvizMediaType;
 import dev.enola.thing.impl.ImmutableThing;
 import dev.enola.thing.message.JavaThingToProtoThingConverter;
 import dev.enola.thing.message.ProtoThingIntoJavaThingBuilderConverter;
@@ -68,7 +71,14 @@ import java.util.stream.StreamSupport;
 public class MarkdownSiteGeneratorTest {
 
     @Rule
-    public SingletonRule r = $(MediaTypeProviders.set(new RdfMediaTypes(), new GexfMediaType()));
+    public SingletonRule r =
+            $(
+                    MediaTypeProviders.set(
+                            new RdfMediaTypes(),
+                            new GexfMediaType(),
+                            new GraphvizMediaType(),
+                            new MarkdownMediaTypes(),
+                            new StandardMediaTypes()));
 
     @Rule
     public TestRule tlcRule =

--- a/java/dev/enola/thing/io/ThingMediaTypesTest.java
+++ b/java/dev/enola/thing/io/ThingMediaTypesTest.java
@@ -23,7 +23,6 @@ import static dev.enola.common.context.testlib.SingletonRule.$;
 
 import dev.enola.common.context.testlib.SingletonRule;
 import dev.enola.common.context.testlib.TestTLCRule;
-import dev.enola.common.io.mediatype.MediaTypeProvider;
 import dev.enola.common.io.mediatype.MediaTypeProviders;
 import dev.enola.common.io.mediatype.YamlMediaType;
 import dev.enola.common.io.resource.FileResource;
@@ -51,20 +50,8 @@ public class ThingMediaTypesTest {
                 .containsKey(".thing.yaml");
     }
 
-    // TODO This makes no sense (anymore, now)... check's MediaTypeProvider is un-used!
-    // Remove it, and fold these two separate but (now) really identically tests into a single one.
-
     @Test
-    public void viaThingMediaTypes() throws URISyntaxException {
-        check(new ThingMediaTypes());
-    }
-
-    @Test
-    public void viaMediaTypeProviders() throws URISyntaxException {
-        check(MediaTypeProviders.SINGLETON.get());
-    }
-
-    private void check(MediaTypeProvider mediaTypeProvider) throws URISyntaxException {
+    public void thingYAML() throws URISyntaxException {
         var rp = new ResourceProviders(new FileResource.Provider());
         var resource = rp.getResource(new URI("file:/picasso.thing.yaml"));
         assertThat(resource.mediaType()).isEqualTo(ThingMediaTypes.THING_YAML_UTF_8);

--- a/java/dev/enola/thing/io/ThingMediaTypesTest.java
+++ b/java/dev/enola/thing/io/ThingMediaTypesTest.java
@@ -51,6 +51,9 @@ public class ThingMediaTypesTest {
                 .containsKey(".thing.yaml");
     }
 
+    // TODO This makes no sense (anymore, now)... check's MediaTypeProvider is un-used!
+    // Remove it, and fold these two separate but (now) really identically tests into a single one.
+
     @Test
     public void viaThingMediaTypes() throws URISyntaxException {
         check(new ThingMediaTypes());


### PR DESCRIPTION
Fixes broken `ThingMediaTypesTest` which failed on some environments (but passed on CI; due to ordering?).

Starts to clean up the `dev.enola.common.io.mediatype` mess.