### PR TITLE
build(deps): Bump google-java-formatter-version from 1.21.0 to 1.25.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,7 +113,7 @@ repos:
     hooks:
       - id: pretty-format-java
         # Keep this version in sync with the same version in .vscode/settings.json
-        args: [--autofix, --aosp, --google-java-formatter-version=1.21.0]
+        args: [--autofix, --aosp, --google-java-formatter-version=1.25.1]
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.13.0

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -72,7 +72,7 @@
   "java.format.settings.google.extra": "--aosp", // For 4 instead of 2 spaces!
   // Keep this version in sync with the same version in .pre-commit-config.yaml
   // NB: Changes to this are only taken into account on start-up, so need to restart.
-  "java.format.settings.google.version": "1.21.0",
+  "java.format.settings.google.version": "1.25.1",
   // TODO https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3050
   "java.compile.nullAnalysis.mode": "automatic",
   "java.completion.importOrder": ["#", "", "javax", "java"], //# is static

--- a/java/dev/enola/thing/metadata/ThingHierarchyProvider.java
+++ b/java/dev/enola/thing/metadata/ThingHierarchyProvider.java
@@ -86,7 +86,7 @@ public class ThingHierarchyProvider {
                 if (!iterator.hasNext()) continue;
                 var parent = iterator.next();
                 return switch (parent) {
-                        // TODO This is a kind of converter, and shouldn't be here?
+                    // TODO This is a kind of converter, and shouldn't be here?
                     case String string -> Optional.of(string);
                     case URI uri -> Optional.of(uri.toString());
                     case Link link -> Optional.of(link.iri());


### PR DESCRIPTION
Unlocked by #698 having been fixed.