### PR TITLE
fix (build): Pin JBang version to 0.122.0, because 0.123.0 breaks the build

### DIFF
--- a/tools/maven/test.bash
+++ b/tools/maven/test.bash
@@ -19,4 +19,5 @@ set -euox pipefail
 
 tools/maven/install.bash
 
-learn/jbang/jbang learn/jbang/hello.java
+# TODO https://github.com/jbangdev/jbang/issues/1921, due to https://github.com/enola-dev/enola/issues/1040
+rm -f ~/.jbang/bin/jbang.jar && JBANG_DOWNLOAD_VERSION=0.122.0 learn/jbang/jbang learn/jbang/hello.java


### PR DESCRIPTION
see #1040