### PR TITLE
fix (build): Pin JBang version to 0.122.0, because 0.123.0 breaks the build

### DIFF
--- a/tools/maven/test.bash
+++ b/tools/maven/test.bash
@@ -19,4 +19,5 @@ set -euox pipefail
 
 tools/maven/install.bash
 
-learn/jbang/jbang learn/jbang/hello.java
+# TODO https://github.com/jbangdev/jbang/issues/1921, due to https://github.com/enola-dev/enola/issues/1040
+rm -rf ~/.jbang/ && JBANG_DOWNLOAD_VERSION=0.122.0 learn/jbang/jbang learn/jbang/hello.java


### PR DESCRIPTION
Relates to #1040.

This is a better solution than #1041 (because it wipes not just `~/.jbang/bin/jbang.jar` but all of `~/.jbang/`; which is [only] what reproduces #1040).