### PR TITLE
clean (core): Simplify generics by using covariant return types

### DIFF
--- a/java/dev/enola/common/io/iri/namespace/NamespaceRepositoryBuilder.java
+++ b/java/dev/enola/common/io/iri/namespace/NamespaceRepositoryBuilder.java
@@ -23,8 +23,7 @@ import dev.enola.data.RepositoryBuilder;
 
 import java.util.Optional;
 
-public class NamespaceRepositoryBuilder
-        extends RepositoryBuilder<NamespaceRepositoryBuilder, Namespace> {
+public class NamespaceRepositoryBuilder extends RepositoryBuilder<Namespace> {
 
     protected final ImmutableSortedMap.Builder<String, String> prefixes =
             ImmutableSortedMap.naturalOrder();

--- a/java/dev/enola/data/RepositoryBuilder.java
+++ b/java/dev/enola/data/RepositoryBuilder.java
@@ -28,8 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /** RepositoryBuilder builds immutable {@link Repository} instances. */
-public abstract class RepositoryBuilder<B extends RepositoryBuilder<B, T>, T>
-        implements Store<RepositoryBuilder<B, T>, T>, Builder<Repository<T>> {
+public abstract class RepositoryBuilder<T> implements Store<T>, Builder<Repository<T>> {
 
     private final Map<String, T> map = new HashMap<>();
 
@@ -48,8 +47,7 @@ public abstract class RepositoryBuilder<B extends RepositoryBuilder<B, T>, T>
 
     @Override
     @CanIgnoreReturnValue
-    @SuppressWarnings("unchecked")
-    public final B store(T item) {
+    public RepositoryBuilder<T> store(T item) {
         var iri = getIRI(item);
         var existing = map.putIfAbsent(iri, item);
         if (existing != null)
@@ -58,13 +56,13 @@ public abstract class RepositoryBuilder<B extends RepositoryBuilder<B, T>, T>
                             + " cannot replace "
                             + existing
                             + "; but consider using merge() instead of store()");
-        return (B) this;
+        return this;
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public B storeAll(Iterable<T> items) { // skipcq: JAVA-W1016
-        return (B) Store.super.storeAll(items);
+    public RepositoryBuilder<T> storeAll(Iterable<T> items) { // skipcq: JAVA-W1016
+        Store.super.storeAll(items);
+        return this;
     }
 
     @Override

--- a/java/dev/enola/data/RepositoryRW.java
+++ b/java/dev/enola/data/RepositoryRW.java
@@ -18,4 +18,4 @@
 package dev.enola.data;
 
 /** RepositoryRW is a readable & writable {@link Repository} which is thus also a {@link Store}. */
-public interface RepositoryRW<T> extends Repository<T>, Store<RepositoryRW<T>, T> {}
+public interface RepositoryRW<T> extends Repository<T>, Store<T> {}

--- a/java/dev/enola/data/Store.java
+++ b/java/dev/enola/data/Store.java
@@ -26,7 +26,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
  * {@link StoreKV}, but their external API is {@link #store(T value)} instead of {@link
  * StoreKV#store(Object, Object)} simply because they internally extract a key from T.
  */
-public interface Store<B extends Store<B, T>, T> {
+public interface Store<T> {
 
     // TODO Combine #store() and #merge() after all?!
 
@@ -47,21 +47,14 @@ public interface Store<B extends Store<B, T>, T> {
      * @throws IllegalArgumentException if this store already has this T
      */
     @CanIgnoreReturnValue
-    B store(T item);
+    Store<T> store(T item);
 
     /** Store multiple Ts; see {@link #store(Object)}. */
     @CanIgnoreReturnValue
-    @SuppressWarnings("unchecked")
-    default B storeAll(Iterable<T> items) {
+    default Store<T> storeAll(Iterable<T> items) {
         for (T item : items) {
             store(item);
         }
-        return (B) this;
-    }
-
-    default void store(T... items) {
-        for (T item : items) {
-            store(item);
-        }
+        return this;
     }
 }

--- a/java/dev/enola/data/StoreKV.java
+++ b/java/dev/enola/data/StoreKV.java
@@ -20,8 +20,8 @@ package dev.enola.data;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
 /** StoreKV store Values so that they can be retrieved again later by Key. */
-public interface StoreKV<B, K, V> {
+public interface StoreKV<K, V> {
 
     @CanIgnoreReturnValue
-    B store(K key, V value);
+    StoreKV<K, V> store(K key, V value);
 }

--- a/java/dev/enola/datatype/DatatypeRepositoryBuilder.java
+++ b/java/dev/enola/datatype/DatatypeRepositoryBuilder.java
@@ -23,12 +23,23 @@ import dev.enola.data.RepositoryBuilder;
 
 import java.util.Optional;
 
-public class DatatypeRepositoryBuilder
-        extends RepositoryBuilder<DatatypeRepositoryBuilder, Datatype<?>> {
+public class DatatypeRepositoryBuilder extends RepositoryBuilder<Datatype<?>> {
 
     @Override
     protected String getIRI(Datatype<?> datatype) {
         return require(datatype.iri(), "iri");
+    }
+
+    @Override
+    public DatatypeRepositoryBuilder store(Datatype<?> item) {
+        super.store(item);
+        return this;
+    }
+
+    @Override
+    public DatatypeRepositoryBuilder storeAll(Iterable<Datatype<?>> items) {
+        super.storeAll(items);
+        return this;
     }
 
     @Override

--- a/java/dev/enola/thing/io/Loader.java
+++ b/java/dev/enola/thing/io/Loader.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.stream.Stream;
 
-public class Loader implements ConverterInto<Stream<URI>, Store<?, Thing>> {
+public class Loader implements ConverterInto<Stream<URI>, Store<Thing>> {
 
     // TODO Move Glob-based loading from CommandWithModel into here!
 
@@ -47,7 +47,7 @@ public class Loader implements ConverterInto<Stream<URI>, Store<?, Thing>> {
     }
 
     @Override
-    public boolean convertInto(Stream<URI> stream, Store<?, Thing> store)
+    public boolean convertInto(Stream<URI> stream, Store<Thing> store)
             throws ConversionException, IOException {
 
         stream.forEach(resource -> load(resource, store));
@@ -55,11 +55,11 @@ public class Loader implements ConverterInto<Stream<URI>, Store<?, Thing>> {
         return true;
     }
 
-    public boolean load(String uri, Store<?, Thing> store) {
+    public boolean load(String uri, Store<Thing> store) {
         return load(URI.create(uri), store);
     }
 
-    public boolean load(URI uri, Store<?, Thing> store) {
+    public boolean load(URI uri, Store<Thing> store) {
         LOG.info("Loading {}...", uri);
         var things = uriIntoThingConverters.convert(uri);
         if (Iterables.isEmpty(things)) return false;

--- a/java/dev/enola/thing/repo/ThingMemoryRepositoryROBuilder.java
+++ b/java/dev/enola/thing/repo/ThingMemoryRepositoryROBuilder.java
@@ -25,8 +25,7 @@ import dev.enola.thing.Thing;
  *
  * <p>{@link ThingMemoryRepositoryRW} is one of possibly several other alternatives for this.
  */
-public class ThingMemoryRepositoryROBuilder
-        extends RepositoryBuilder<ThingMemoryRepositoryROBuilder, Thing> {
+public class ThingMemoryRepositoryROBuilder extends RepositoryBuilder<Thing> {
 
     @Override
     protected String getIRI(Thing thing) {
@@ -36,6 +35,18 @@ public class ThingMemoryRepositoryROBuilder
     @Override
     protected Thing merge(Thing existing, Thing update) {
         return ThingMerger.merge(existing, update);
+    }
+
+    @Override
+    public ThingMemoryRepositoryROBuilder store(Thing item) {
+        super.store(item);
+        return this;
+    }
+
+    @Override
+    public ThingMemoryRepositoryROBuilder storeAll(Iterable<Thing> items) {
+        super.storeAll(items);
+        return this;
     }
 
     @Override

--- a/java/dev/enola/thing/repo/ThingRepositoriesTest.java
+++ b/java/dev/enola/thing/repo/ThingRepositoriesTest.java
@@ -47,7 +47,7 @@ public class ThingRepositoriesTest {
                                     new Literal("k&ç#'", "test:type")))
                     .build();
 
-    private void checkStore(Store<?, Thing> thingStore) {
+    private void checkStore(Store<Thing> thingStore) {
         thingStore.store(TEST_THING);
         assertThrows(IllegalArgumentException.class, () -> thingStore.store(TEST_THING));
     }

--- a/java/dev/enola/thing/validation/LinksValidatorTest.java
+++ b/java/dev/enola/thing/validation/LinksValidatorTest.java
@@ -27,6 +27,8 @@ import dev.enola.thing.repo.ThingRepositoryStore;
 
 import org.junit.Test;
 
+import java.util.List;
+
 public class LinksValidatorTest {
 
     // TODO Add missing test coverage for (working) blank nodes, Iterables, URI instead Link
@@ -61,14 +63,14 @@ public class LinksValidatorTest {
 
     @Test
     public void aok() {
-        repo.store(one, two);
+        repo.storeAll(List.of(one, two));
         v.validate(repo, collector);
         assertThat(collector.getDiagnostics()).isEmpty();
     }
 
     @Test
     public void bad() {
-        repo.store(one, two, bad1, bad2);
+        repo.storeAll(List.of(one, two, bad1, bad2));
         v.validate(repo, collector);
         assertThat(collector.getDiagnostics()).hasSize(2);
     }

--- a/java/dev/enola/zimpl/EnolaProvider.java
+++ b/java/dev/enola/zimpl/EnolaProvider.java
@@ -50,8 +50,7 @@ public class EnolaProvider {
         return new EnolaImplementation(actionsRepo, converter);
     }
 
-    private static class ActionRepositoryBuilder
-            extends RepositoryBuilder<ActionRepositoryBuilder, Action<?, ?>> {
+    private static class ActionRepositoryBuilder extends RepositoryBuilder<Action<?, ?>> {
 
         @Override
         protected String getIRI(Action<?, ?> action) {


### PR DESCRIPTION
Covariant return types can also do this, and are simpler - just at the expense of a little bit of repetion.