### PR TITLE
build(deps): Enable future Bun managed package version bumps in Depenabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,10 @@ updates:
       day: monday
       time: "04:00"
     open-pull-requests-limit: 99
+  - package-ecosystem: "bun"
+    commit-message:
+      prefix: "build(deps): "
+    directory: "web/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 99

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -178,14 +178,15 @@ repos:
         exclude: mvnw
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.30.0
+    rev: 0.31.1
     hooks:
       - id: check-github-actions
         args: ["--verbose"]
       - id: check-github-workflows
         args: ["--verbose"]
-      - id: check-dependabot
-        args: ["--verbose"]
+      # TODO https://github.com/python-jsonschema/check-jsonschema/issues/528
+      # - id: check-dependabot
+      #   args: ["--verbose"]
       - id: check-renovate
         args: ["--verbose"]
         additional_dependencies: ["pyjson5==1.6.7"]


### PR DESCRIPTION
See https://github.com/dependabot/dependabot-core/issues/6528.

Also temporarily deactivate the [pre-commit](https://pre-commit.com/) for [`check-jsonschema`](https://github.com/python-jsonschema/check-jsonschema), until https://github.com/python-jsonschema/check-jsonschema/issues/528 is resolved.