### PR TITLE
fix (build): Do not re-use the GRPC_JAVA_VERSION for the grpc-java mod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,9 @@
 
 # Nota bene, any shared version numbers defined here should ONLY be
 # for Maven versions (of multiple artifacts), and NOT also used in bazel_dep()
-# mod versions; because of https://github.com/VirtusLab/bazel-steward/issues/404.
+# mod versions; because bazel-steward may update the variable but
+# not the bazel_dep, or vice versa, leading to inconsistencies (see
+# https://github.com/VirtusLab/bazel-steward/issues/404).
 
 RDF4J_VERSION = "5.1.2"
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Nota bene, any shared version numbers defined here should ONLY be
+# for Maven versions (of multiple artifacts), and NOT also used in bazel_dep()
+# mod versions; because of https://github.com/VirtusLab/bazel-steward/issues/404.
+
 RDF4J_VERSION = "5.1.2"
 
 GRPC_JAVA_VERSION = "1.69.0"
@@ -48,7 +52,8 @@ switched_rules.use_languages(java = True)
 # https://registry.bazel.build/modules/grpc-java
 # TODO Bump grpc-java version to avoid ugly WARNING & DEBUG once https://github.com/grpc/grpc-java/issues/11792
 #  and https://github.com/grpc/grpc-java/issues/11791 are fixed (and released).
-bazel_dep(name = "grpc-java", version = GRPC_JAVA_VERSION, repo_name = "io_grpc_grpc_java")
+# NB: Do *NOT* re-use GRPC_JAVA_VERSION here, because of https://github.com/VirtusLab/bazel-steward/issues/404.
+bazel_dep(name = "grpc-java", version = "1.69.0", repo_name = "io_grpc_grpc_java")
 
 # https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/bzlmod.md
 bazel_dep(name = "rules_go", version = "0.51.0")


### PR DESCRIPTION
See https://github.com/VirtusLab/bazel-steward/issues/404 for background.

@lukaszwawrzyk is this an "appropriate" fix for what you meant by _"variable is shared between bzlmod dep and maven deps"?_