### PR TITLE
fix (build): Add bazel-steward.jar to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ tools/version/VERSION
 
 # LinkML
 .built
+
+# https://github.com/VirtusLab/bazel-steward/issues/424
+bazel-steward.jar


### PR DESCRIPTION
Due to https://github.com/VirtusLab/bazel-steward/issues/424.

Relates to #254.