### PR TITLE
Invoke evilurl via Bazel

### DIFF
--- a/java/BUILD
+++ b/java/BUILD
@@ -13,3 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+sh_test(
+    name = "evilurl",
+    srcs = ["evilurl.bash"],
+    # TODO How to make this work despite the presence of **/BUILD files?!
+    data = glob(["**/*.java"]),
+)

--- a/java/evilurl.bash
+++ b/java/evilurl.bash
@@ -26,11 +26,14 @@
 
 set -euo pipefail
 
+
 allow_list=("java/dev/enola/common/io/resource/UrlResource.java"
             "java/dev/enola/common/io/resource/ClasspathResource.java")
 
 # TODO Also grep for .toURL() invocations, and fail for any (new) ones.
 
+echo -n "CDW = "
+pwd
 found_files=$(find . -name "*.java" -print0 | xargs -0 grep -lE "(^|[^a-zA-Z0-9_.])java\.net\.URL($|[^a-zA-Z0-9_#}])" | while IFS= read -r file; do
     file_name=$(basename "$file")
     allow_path="${file//.\//}"

--- a/test.bash
+++ b/test.bash
@@ -39,9 +39,6 @@ fi
 
 tools/version/version.bash
 
-# TODO Remove this once evilurl is Bazel test BUILD integrated...
-tools/evilurl/test.bash
-
 # https://github.com/bazelbuild/bazel/issues/4257
 echo $ Bazel testing...
 if [ -z "${CI:-""}" ]; then


### PR DESCRIPTION
NOK Draft, WIP; ` bazelisk test //java:evilurl` still fails (now) with:

```
ERROR: Traceback (most recent call last):
        File "/home/vorburger/git/github.com/enola-dev/enola/java/BUILD", line 21, column 16, in <toplevel>
                data = glob(["**/*.java"]),
Error in glob: glob pattern '**/*.java' didn't match anything, but allow_empty is set to False (the default value of allow_empty can be set with --incompatible_disallow_empty_glob).
```

because there are (of course) [many other] `BUILD` file within `java/`... which makes Bazel "hide" their `**/*.java`.

How does one do this, with Bazel? There must be some way.

Asked on https://stackoverflow.com/q/79495663/421602.

Might [this](https://stackoverflow.com/questions/76551753/how-do-i-wrap-all-files-from-a-bazel-filegroup-into-a-directory) be a way? Complicated...