### PR TITLE
fix (build): CLI bazel target overlap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ tools/version/VERSION
 
 # https://github.com/VirtusLab/bazel-steward/issues/424
 bazel-steward.jar
+
+# Bazel BSP, by https://docs.google.com/document/d/1fdLN1iONuRm--PhpDNYXpEOPPwKML8bG5OJv9AbCvEI/edit?tab=t.0
+.bazelbsp/

--- a/java/dev/enola/cli/BUILD
+++ b/java/dev/enola/cli/BUILD
@@ -87,6 +87,18 @@ java_library(
     ],
 )
 
+java_library(
+    name = "testlib",
+    srcs = [
+        "CommandLineSubject.java",
+        "SystemOutErrCapture.java",
+    ],
+    deps = [
+        "//java/dev/enola/cli/common",
+        "@enola_maven//:com_google_truth_truth",
+    ],
+)
+
 junit_tests(
     name = "tests",
     size = "medium",
@@ -94,12 +106,9 @@ junit_tests(
         ["*Test.java"],
         exclude = ["EnolaLoggingTest.java"],
     ),
-    srcs_utils = [
-        "CommandLineSubject.java",
-        "SystemOutErrCapture.java",
-    ],
     deps = [
         ":lib",
+        ":testlib",
         "//java/dev/enola/cli/common",
         "//java/dev/enola/common/canonicalize",
         "//java/dev/enola/common/context/testlib",
@@ -123,9 +132,7 @@ junit_tests(
 java_test(
     name = "EnolaLoggingTest",
     srcs = [
-        "CommandLineSubject.java",
         "EnolaLoggingTest.java",
-        "SystemOutErrCapture.java",
     ],
     runtime_deps = [
         "//java/dev/enola/common/canonicalize",
@@ -140,6 +147,7 @@ java_test(
     ],
     deps = [
         ":lib",
+        ":testlib",
         "//java/dev/enola/cli/common",
         "//java/dev/enola/common/context/testlib",
         "//java/dev/enola/thing:thing_java",


### PR DESCRIPTION
```
Targets @//java/dev/enola/cli:EnolaLoggingTest and @//java/dev/enola/cli:tests share CommandLineSubject.java.

Please exclude one of the targets in the selected project view file to avoid erroneous highlighting.
```