### PR TITLE
build: Depend on pyjson5 in requirements.txt instead of pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -189,7 +189,7 @@ repos:
       #   args: ["--verbose"]
       - id: check-renovate
         args: ["--verbose"]
-        additional_dependencies: ["pyjson5==1.6.7"]
+        additional_dependencies: ["pyjson5"]
       - id: check-metaschema
         files: \.schema\.json$
         args: ["--verbose"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,10 @@
 # https://pre-commit.com
 pre-commit==4.1.0
 
+# https://github.com/Kijewski/pyjson5
+# Used as additional_dependencies in check-renovate pre-commit.
+pyjson5==1.6.8
+
 # https://linkml.io
 linkml==1.8.7
 


### PR DESCRIPTION
Relates to https://github.com/python-jsonschema/check-jsonschema/issues/542.

But this shouldn't be needed?