### PR TITLE
Fix Thing.add[All]{Build}Add root cause of lists of lists

### DIFF
--- a/java/dev/enola/infer/rdf/BUILD
+++ b/java/dev/enola/infer/rdf/BUILD
@@ -41,7 +41,6 @@ junit_tests(
     name = "tests",
     srcs = glob(
         include = ["*Test.java"],
-        allow_empty = True,
     ),
     deps = [
         ":rdf",

--- a/java/dev/enola/infer/rdf/RDFSTriggersIntegrationTest.java
+++ b/java/dev/enola/infer/rdf/RDFSTriggersIntegrationTest.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2025 The Enola <https://enola.dev> Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.enola.infer.rdf;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import static dev.enola.common.context.testlib.SingletonRule.$;
+
+import com.google.common.collect.ImmutableList;
+
+import dev.enola.common.context.TLC;
+import dev.enola.common.context.testlib.SingletonRule;
+import dev.enola.common.io.mediatype.MediaTypeProviders;
+import dev.enola.common.io.resource.ClasspathResource;
+import dev.enola.datatype.DatatypeRepository;
+import dev.enola.model.w3.rdf.Property;
+import dev.enola.rdf.io.RdfMediaTypes;
+import dev.enola.rdf.io.RdfResourceIntoThingConverter;
+import dev.enola.thing.KIRI;
+import dev.enola.thing.impl.ImmutableThing;
+import dev.enola.thing.io.Loader;
+import dev.enola.thing.io.UriIntoThingConverters;
+import dev.enola.thing.java.ProxyTBF;
+import dev.enola.thing.java.TBF;
+import dev.enola.thing.java.TypeToBuilder;
+import dev.enola.thing.repo.AlwaysThingRepositoryStore;
+import dev.enola.thing.repo.ThingMemoryRepositoryRW;
+import dev.enola.thing.repo.ThingProvider;
+import dev.enola.thing.repo.ThingRepositoryStore;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class RDFSTriggersIntegrationTest {
+
+    @Rule public SingletonRule r = $(MediaTypeProviders.set(new RdfMediaTypes()));
+
+    @Test
+    @Ignore // TODO FIXME
+    public void rdfs() throws IOException {
+        var trigger = new RDFSPropertyTrigger();
+        ThingRepositoryStore repo = new ThingMemoryRepositoryRW(ImmutableList.of(trigger));
+        repo = new AlwaysThingRepositoryStore(repo);
+        trigger.setRepo(repo);
+
+        var tbf = new ProxyTBF(ImmutableThing.FACTORY);
+        try (var ctx = TLC.open().push(TBF.class, tbf).push(ThingProvider.class, repo)) {
+
+            var rp = new ClasspathResource.Provider();
+            var rdfConverter = new RdfResourceIntoThingConverter<>(rp, DatatypeRepository.EMPTY);
+            var converters = new UriIntoThingConverters(rdfConverter);
+            var loader = new Loader(converters);
+            loader.load("classpath:/www.w3.org/rdf.ttl", repo);
+            loader.load("classpath:/www.w3.org/rdf-schema.ttl", repo);
+
+            assertThat(repo.listIRI())
+                    .contains("http://www.w3.org/1999/02/22-rdf-syntax-ns#Property");
+            var propertyThing = repo.get("http://www.w3.org/1999/02/22-rdf-syntax-ns#Property");
+            assertThat(propertyThing.predicateIRIs()).contains("https://enola.dev/properties");
+            var properties = propertyThing.get("https://enola.dev/properties", Iterable.class);
+            assertThat(properties)
+                    .containsExactly(
+                            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+                            "http://www.w3.org/2000/01/rdf-schema#domain",
+                            "http://www.w3.org/2000/01/rdf-schema#range");
+        }
+    }
+
+    @Test
+    public void testSomethingBuilder() {
+        var pair = TypeToBuilder.typeToBuilder(KIRI.RDF.PROPERTY);
+        assertThat(pair.builderClass()).isEqualTo(Property.Builder.class);
+        assertThat(pair.thingClass()).isEqualTo(Property.class);
+    }
+}

--- a/java/dev/enola/infer/rdf/RDFSTriggersIntegrationTest.java
+++ b/java/dev/enola/infer/rdf/RDFSTriggersIntegrationTest.java
@@ -32,6 +32,7 @@ import dev.enola.model.w3.rdf.Property;
 import dev.enola.rdf.io.RdfMediaTypes;
 import dev.enola.rdf.io.RdfResourceIntoThingConverter;
 import dev.enola.thing.KIRI;
+import dev.enola.thing.Link;
 import dev.enola.thing.impl.ImmutableThing;
 import dev.enola.thing.io.Loader;
 import dev.enola.thing.io.UriIntoThingConverters;
@@ -43,7 +44,6 @@ import dev.enola.thing.repo.ThingMemoryRepositoryRW;
 import dev.enola.thing.repo.ThingProvider;
 import dev.enola.thing.repo.ThingRepositoryStore;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -54,7 +54,6 @@ public class RDFSTriggersIntegrationTest {
     @Rule public SingletonRule r = $(MediaTypeProviders.set(new RdfMediaTypes()));
 
     @Test
-    @Ignore // TODO FIXME
     public void rdfs() throws IOException {
         var trigger = new RDFSPropertyTrigger();
         ThingRepositoryStore repo = new ThingMemoryRepositoryRW(ImmutableList.of(trigger));
@@ -78,9 +77,9 @@ public class RDFSTriggersIntegrationTest {
             var properties = propertyThing.get("https://enola.dev/properties", Iterable.class);
             assertThat(properties)
                     .containsExactly(
-                            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
-                            "http://www.w3.org/2000/01/rdf-schema#domain",
-                            "http://www.w3.org/2000/01/rdf-schema#range");
+                            new Link("http://www.w3.org/2000/01/rdf-schema#subPropertyOf"),
+                            new Link("http://www.w3.org/2000/01/rdf-schema#domain"),
+                            new Link("http://www.w3.org/2000/01/rdf-schema#range"));
         }
     }
 

--- a/java/dev/enola/thing/Link.java
+++ b/java/dev/enola/thing/Link.java
@@ -41,6 +41,7 @@ public record Link(String iri) implements HasIRI {
 
     @Override
     public String toString() {
+        // TODO return "<" + iri + ">";
         return iri;
     }
 }

--- a/java/dev/enola/thing/ThingTester.java
+++ b/java/dev/enola/thing/ThingTester.java
@@ -77,16 +77,6 @@ public abstract class ThingTester {
     }
 
     @Test
-    @Ignore // inOrder() is *NOT* guaranteed to be deterministic [anymore]
-    public void insertionInOrder() {
-        thingBuilder.iri(THING_IRI);
-        thingBuilder.set("b", "B");
-        thingBuilder.set("a", "A");
-        var thing = thingBuilder.build();
-        assertThat(thing.predicateIRIs()).containsExactly("b", "a").inOrder();
-    }
-
-    @Test
     public void datatype1() {
         thingBuilder.iri(THING_IRI);
         var value = "http://example.org/hi/{NUMBER}";
@@ -232,7 +222,7 @@ public abstract class ThingTester {
         thingBuilder.set(PREDICATE_IRI, "x");
         thingBuilder.addOrdered(PREDICATE_IRI, "a");
         var thing = thingBuilder.build();
-        assertThat(thing.get(PREDICATE_IRI, Iterable.class)).containsExactly("a", "x");
+        assertThat(thing.get(PREDICATE_IRI, Iterable.class)).containsExactly("x", "a").inOrder();
     }
 
     @Test
@@ -241,17 +231,19 @@ public abstract class ThingTester {
         thingBuilder.add(PREDICATE_IRI, "x");
         thingBuilder.addOrdered(PREDICATE_IRI, "a");
         var thing = thingBuilder.build();
-        assertThat(thing.get(PREDICATE_IRI, Iterable.class)).containsExactly("a", "x");
+        assertThat(thing.get(PREDICATE_IRI, Iterable.class)).containsExactly("x", "a").inOrder();
     }
 
     @Test
     public void addToOrdered() {
         thingBuilder.iri(THING_IRI);
+        thingBuilder.addOrdered(PREDICATE_IRI, "c");
         thingBuilder.addOrdered(PREDICATE_IRI, "b");
-        thingBuilder.addOrdered(PREDICATE_IRI, "a");
-        thingBuilder.add(PREDICATE_IRI, "c");
+        thingBuilder.add(PREDICATE_IRI, "a");
         var thing = thingBuilder.build();
-        assertThat(thing.get(PREDICATE_IRI, Iterable.class)).containsExactly("a", "b", "c");
+        assertThat(thing.get(PREDICATE_IRI, Iterable.class))
+                .containsExactly("c", "b", "a")
+                .inOrder();
     }
 
     @Test
@@ -261,7 +253,9 @@ public abstract class ThingTester {
         thingBuilder.addOrdered(PREDICATE_IRI, "a");
         thingBuilder.addAll(PREDICATE_IRI, List.of("d", "c"));
         var thing = thingBuilder.build();
-        assertThat(thing.get(PREDICATE_IRI, Iterable.class)).containsExactly("a", "b", "c", "d");
+        assertThat(thing.get(PREDICATE_IRI, Iterable.class))
+                .containsExactly("b", "a", "d", "c")
+                .inOrder();
     }
 
     @Test
@@ -284,7 +278,7 @@ public abstract class ThingTester {
         thingBuilder.iri(THING_IRI);
         thingBuilder.addAllOrdered(PREDICATE_IRI, List.of("b", "a"));
         var thing = thingBuilder.build();
-        assertThat(thing.get(PREDICATE_IRI, Iterable.class)).containsExactly("a", "b");
+        assertThat(thing.get(PREDICATE_IRI, Iterable.class)).containsExactly("b", "a").inOrder();
     }
 
     @Test
@@ -293,9 +287,11 @@ public abstract class ThingTester {
         thingBuilder.addAllOrdered(PREDICATE_IRI, List.of("b", "a"));
         var thing1 = thingBuilder.build();
         var thingBuilder2 = thing1.copy();
-        thingBuilder2.addAllOrdered(PREDICATE_IRI, List.of("c", "d"));
+        thingBuilder2.addAllOrdered(PREDICATE_IRI, List.of("d", "c"));
         var thing2 = thingBuilder2.build();
-        assertThat(thing2.get(PREDICATE_IRI, Iterable.class)).containsExactly("a", "b", "c", "d");
+        assertThat(thing2.get(PREDICATE_IRI, Iterable.class))
+                .containsExactly("b", "a", "d", "c")
+                .inOrder();
     }
 
     @Test

--- a/java/dev/enola/thing/ThingTester.java
+++ b/java/dev/enola/thing/ThingTester.java
@@ -156,11 +156,37 @@ public abstract class ThingTester {
     }
 
     @Test
+    public void addBuildAdd() {
+        thingBuilder.iri(THING_IRI);
+        thingBuilder.add(PREDICATE_IRI, "a");
+        var thing1 = thingBuilder.build();
+        var thingBuilder2 = thing1.copy();
+        thingBuilder2.add(PREDICATE_IRI, "b");
+        var thing2 = thingBuilder2.build();
+        assertThat(thing2.get(PREDICATE_IRI, Iterable.class)).containsExactly("a", "b");
+        assertThat(thing2.isIterable(PREDICATE_IRI)).isTrue();
+        assertThat(thing2.isOrdered(PREDICATE_IRI)).isFalse();
+        assertThat(thing2.get(PREDICATE_IRI, Iterable.class)).isInstanceOf(ImmutableSet.class);
+    }
+
+    @Test
     public void addAll() {
         thingBuilder.iri(THING_IRI);
         thingBuilder.addAll(PREDICATE_IRI, List.of("a", "b"));
         var thing = thingBuilder.build();
         assertThat(thing.get(PREDICATE_IRI, Iterable.class)).containsExactly("a", "b");
+    }
+
+    @Test
+    public void addAllBuildAddAll() {
+        thingBuilder.iri(THING_IRI);
+        thingBuilder.addAll(PREDICATE_IRI, List.of("a", "b"));
+        var thing1 = thingBuilder.build();
+        var thingBuilder2 = thing1.copy();
+
+        thingBuilder2.addAll(PREDICATE_IRI, List.of("c", "d"));
+        var thing2 = thingBuilder2.build();
+        assertThat(thing2.get(PREDICATE_IRI, Iterable.class)).containsExactly("a", "b", "c", "d");
     }
 
     @Test
@@ -239,11 +265,37 @@ public abstract class ThingTester {
     }
 
     @Test
+    public void addOrderedBuildAddOrdered() {
+        thingBuilder.iri(THING_IRI);
+        thingBuilder.addOrdered(PREDICATE_IRI, "a");
+        thingBuilder.addOrdered(PREDICATE_IRI, "b");
+        var thing1 = thingBuilder.build();
+
+        var thingBuilder2 = thing1.copy();
+        thingBuilder2.addOrdered(PREDICATE_IRI, "c");
+        var thing2 = thingBuilder2.build();
+        assertThat(thing2.get(PREDICATE_IRI, Iterable.class))
+                .containsExactly("a", "b", "c")
+                .inOrder();
+    }
+
+    @Test
     public void addAllOrdered() {
         thingBuilder.iri(THING_IRI);
         thingBuilder.addAllOrdered(PREDICATE_IRI, List.of("b", "a"));
         var thing = thingBuilder.build();
         assertThat(thing.get(PREDICATE_IRI, Iterable.class)).containsExactly("a", "b");
+    }
+
+    @Test
+    public void addAllOrderedBuildAddAllOrdered() {
+        thingBuilder.iri(THING_IRI);
+        thingBuilder.addAllOrdered(PREDICATE_IRI, List.of("b", "a"));
+        var thing1 = thingBuilder.build();
+        var thingBuilder2 = thing1.copy();
+        thingBuilder2.addAllOrdered(PREDICATE_IRI, List.of("c", "d"));
+        var thing2 = thingBuilder2.build();
+        assertThat(thing2.get(PREDICATE_IRI, Iterable.class)).containsExactly("a", "b", "c", "d");
     }
 
     @Test

--- a/java/dev/enola/thing/gen/markdown/MarkdownSiteGeneratorTest.java
+++ b/java/dev/enola/thing/gen/markdown/MarkdownSiteGeneratorTest.java
@@ -154,6 +154,13 @@ public class MarkdownSiteGeneratorTest {
         generate(dir, "template-name-clash.ttl");
     }
 
+    @Test
+    public void listOfList() throws IOException {
+        Path dir = Files.createTempDirectory("MarkdownSiteGeneratorTest-listOfList");
+        generate(dir, "list-of-list.ttl");
+        check(dir, "example.org/list-of-list.md", "list-of-list.md");
+    }
+
     private void generate(Path dir, String classpathResource) throws IOException {
         var converterP2J = new ProtoThingIntoJavaThingBuilderConverter(dtr);
         var loadedProtoThings = load(new ClasspathResource(classpathResource));

--- a/java/dev/enola/thing/gen/markdown/MarkdownThingGenerator.java
+++ b/java/dev/enola/thing/gen/markdown/MarkdownThingGenerator.java
@@ -186,7 +186,8 @@ class MarkdownThingGenerator {
                     out.append(indent);
                     if (list.getOrdered()) out.append("    1. ");
                     else out.append("    * ");
-                    write(indent, element, out, outputIRI, base, isDocumentedIRI, ts);
+                    // NB: indent + "    " is important to correctly visualize nested lists!
+                    write(indent + "    ", element, out, outputIRI, base, isDocumentedIRI, ts);
                 }
                 break;
 

--- a/java/dev/enola/thing/impl/MutablePredicatesObjectsBuilder.java
+++ b/java/dev/enola/thing/impl/MutablePredicatesObjectsBuilder.java
@@ -95,6 +95,11 @@ class MutablePredicatesObjectsBuilder<B extends IImmutablePredicatesObjects>
             builder.add(value);
         } else if (object instanceof ImmutableCollection.Builder builder) {
             builder.add(value);
+        } else if (object instanceof Iterable iterable) {
+            var builder = ImmutableSet.builder();
+            properties.put(predicateIRI, builder);
+            builder.addAll(iterable);
+            builder.add(value);
         } else {
             var builder = ImmutableSet.builder();
             properties.put(predicateIRI, builder);
@@ -116,6 +121,11 @@ class MutablePredicatesObjectsBuilder<B extends IImmutablePredicatesObjects>
             properties.put(predicateIRI, builder);
             builder.addAll(values);
         } else if (object instanceof ImmutableCollection.Builder builder) {
+            builder.addAll(values);
+        } else if (object instanceof Iterable iterable) {
+            var builder = ImmutableSet.builder();
+            properties.put(predicateIRI, builder);
+            builder.addAll(iterable);
             builder.addAll(values);
         } else {
             var builder = ImmutableSet.builder();
@@ -145,6 +155,11 @@ class MutablePredicatesObjectsBuilder<B extends IImmutablePredicatesObjects>
             properties.put(predicateIRI, listBuilder);
             listBuilder.addAll(set);
             listBuilder.add(value);
+        } else if (object instanceof Iterable iterable) {
+            var builder = ImmutableSet.builder();
+            properties.put(predicateIRI, builder);
+            builder.addAll(iterable);
+            builder.add(value);
         } else {
             var builder = ImmutableList.builder();
             properties.put(predicateIRI, builder);
@@ -174,6 +189,11 @@ class MutablePredicatesObjectsBuilder<B extends IImmutablePredicatesObjects>
             properties.put(predicateIRI, listBuilder);
             listBuilder.addAll(set);
             listBuilder.addAll(values);
+        } else if (object instanceof Iterable iterable) {
+            var builder = ImmutableSet.builder();
+            properties.put(predicateIRI, builder);
+            builder.addAll(iterable);
+            builder.addAll(values);
         } else {
             var builder = ImmutableSet.builder();
             properties.put(predicateIRI, builder);

--- a/java/dev/enola/thing/impl/OnlyIRIThing.java
+++ b/java/dev/enola/thing/impl/OnlyIRIThing.java
@@ -20,7 +20,9 @@ package dev.enola.thing.impl;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
+import dev.enola.common.context.TLC;
 import dev.enola.thing.Thing;
+import dev.enola.thing.java.TBF;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -74,7 +76,7 @@ public class OnlyIRIThing implements IImmutableThing {
 
     @Override
     public Thing.Builder<? extends Thing> copy() {
-        return ImmutableThing.builder().iri(iri());
+        return TLC.get(TBF.class).create();
     }
 
     @Override

--- a/java/dev/enola/thing/java/TypeToBuilder.java
+++ b/java/dev/enola/thing/java/TypeToBuilder.java
@@ -17,6 +17,7 @@
  */
 package dev.enola.thing.java;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.Resources;
 import com.google.errorprone.annotations.ThreadSafe;
 
@@ -31,14 +32,17 @@ public class TypeToBuilder {
 
     // TODO Cache in @ThreadSafe (copy-on-write, perhaps?) Map
 
-    record ThingAndBuilderClassPair(Class<Thing> thingClass, Class<Thing.Builder> builderClass) {}
+    @VisibleForTesting
+    public record ThingAndBuilderClassPair(
+            Class<Thing> thingClass, Class<Thing.Builder> builderClass) {}
 
     private static final ThingAndBuilderClassPair DEFAULT =
             new ThingAndBuilderClassPair(Thing.class, Thing.Builder.class);
 
     private static final ClassLoader classLoader = TypeToBuilder.class.getClassLoader();
 
-    static ThingAndBuilderClassPair typeToBuilder(String typeIRI) {
+    @VisibleForTesting
+    public static ThingAndBuilderClassPair typeToBuilder(String typeIRI) {
         var resourceName = "META-INF/dev.enola/" + mangle(typeIRI);
         var url = classLoader.getResource(resourceName);
         if (url == null) return DEFAULT;

--- a/java/dev/enola/thing/repo/ThingProvider.java
+++ b/java/dev/enola/thing/repo/ThingProvider.java
@@ -24,6 +24,7 @@ import dev.enola.common.convert.ConversionException;
 import dev.enola.data.ProviderFromIRI;
 import dev.enola.thing.Thing;
 import dev.enola.thing.ThingConverterInto;
+import dev.enola.thing.impl.OnlyIRIThing;
 import dev.enola.thing.java.TBF;
 import dev.enola.thing.message.ProtoThingProvider;
 
@@ -57,7 +58,7 @@ public interface ThingProvider extends ProviderFromIRI<Thing> {
 
     default Thing.Builder<?> getBuilder(String iri, String typeIRI) {
         var thing = get(Objects.requireNonNull(iri, "iri"));
-        if (thing != null) return thing.copy();
+        if (thing != null && !(thing instanceof OnlyIRIThing)) return thing.copy();
         else return TLC.get(TBF.class).create(typeIRI).iri(iri);
     }
 

--- a/test/list-of-list.md
+++ b/test/list-of-list.md
@@ -1,0 +1,42 @@
+# list-of-list
+
+[http://example.org/list-of-list](http://example.org/list-of-list)
+
+* [list](http://example.org/list):
+    1. [a](http://example.org/a)
+    1. [b](http://example.org/b)
+    1. [c](http://example.org/c)
+* [set](http://example.org/set):
+    * [a](http://example.org/a)
+    * [b](http://example.org/b)
+    * [c](http://example.org/c)
+
+<script type="application/ld+json">
+[
+    {
+        "@id": "http://example.org/list-of-list",
+        "http://example.org/set": [
+            {
+                "@id": "http://example.org/a"
+            },
+            {
+                "@id": "http://example.org/b"
+            },
+            {
+                "@id": "http://example.org/c"
+            }
+        ],
+        "http://example.org/list": [
+            {
+                "@id": "http://example.org/a"
+            },
+            {
+                "@id": "http://example.org/b"
+            },
+            {
+                "@id": "http://example.org/c"
+            }
+        ]
+    }
+]
+</script>

--- a/test/list-of-list.ttl
+++ b/test/list-of-list.ttl
@@ -1,0 +1,13 @@
+@prefix : <http://example.org/>.
+
+:list-of-list
+  :set :a, :b, :c;
+  # TODO :list ( (:a) :b :c );
+  :list ( :a :b :c );
+  # TODO :blank [
+  # TODO   :a [
+  # TODO     :c :d, :e
+  # TODO   ];
+  # TODO   :list ( (:a) :b :c )
+  # TODO ]
+.


### PR DESCRIPTION
This fixes the strange empty bullet points currently seen e.g. [here](https://docs.enola.dev/models/www.w3.org/1999/02/22-rdf-syntax-ns/Property/):

![Screenshot From 2025-03-31 00-44-02](https://github.com/user-attachments/assets/b74e7677-567e-4c3a-a779-c9ae6753ae3e)
