### PR TITLE
build: Attempt (again) to get Bazel Steward 🤵 to include MODULE.bazel.lock

### DIFF
--- a/.bazel-steward.yaml
+++ b/.bazel-steward.yaml
@@ -54,7 +54,7 @@ post-update-hooks:
   # https://github.com/VirtusLab/bazel-steward/issues/422
   - kinds: bzlmod
     commands:
-      - "git add MODULE.bazel.lock"
+      - "bazelisk sync --enable_workspace"
     files-to-commit:
       - "MODULE.bazel.lock"
 


### PR DESCRIPTION
See https://github.com/VirtusLab/bazel-steward/issues/422,

maybe this works better like this than it did in #1273.