### PR TITLE
build: Make Bazel Steward group PicoCLI Bump PRs

### DIFF
--- a/.bazel-steward.yaml
+++ b/.bazel-steward.yaml
@@ -47,6 +47,8 @@ pull-requests:
     dependencies: "org.eclipse.rdf4j:*"
   - group-id: protobuf
     dependencies: "com.google.protobuf:*"
+  - group-id: picocli
+    dependencies: "info.picocli:*"
 
   - title: "Update ${group}/${artifact} from ${versionFrom} to ${versionTo}"
     commit-message: "deps: Update ${group}/${artifact} from ${versionFrom} to ${versionTo}"


### PR DESCRIPTION
So that #1323 + #1324 are a single PR in the future.

Waiting to merge this AFTER #1324 is merged, to avoid confusing Steward.

Relates to #254.