### PR TITLE
fix: Chat echo when STDIN is redirected

### DIFF
--- a/java/dev/enola/chat/ConsoleIOTest.java
+++ b/java/dev/enola/chat/ConsoleIOTest.java
@@ -28,7 +28,7 @@ public class ConsoleIOTest {
         SystemStdinStdoutTester.pipeIn(
                 "hello\nworld\nend", // Intentionally no last \n at the end!
                 () -> {
-                    IO io = new ConsoleIO();
+                    IO io = new DelegatingIO(new ConsoleIO());
                     assertThat(io.readLine()).isEqualTo("hello");
                     assertThat(io.readLine()).isEqualTo("world");
                     assertThat(io.readLine()).isEqualTo("end");
@@ -41,7 +41,7 @@ public class ConsoleIOTest {
                 SystemStdinStdoutTester.captureOut(
                         () -> {
                             System.out.println("hello");
-                            IO io = new ConsoleIO();
+                            IO io = new DelegatingIO(new ConsoleIO());
                             io.printf("world");
                         });
         assertThat(out).isEqualTo("hello\nworld");

--- a/java/dev/enola/chat/DelegatingIO.java
+++ b/java/dev/enola/chat/DelegatingIO.java
@@ -19,29 +19,38 @@ package dev.enola.chat;
 
 import org.jspecify.annotations.Nullable;
 
-import java.io.Console;
+/**
+ * DelegatingIO is an {@link dev.enola.chat.IO} implementation which if STDIN and/or STDOUT have
+ * been redirected reads from there (and "echos" input), and otherwise delegates to another IO
+ * implementation (typically e.g., a {@link dev.enola.chat.ConsoleIO} or a {@link
+ * dev.enola.chat.jline.JLineIO}).
+ */
+public class DelegatingIO implements IO {
 
-/** ConsoleIO is an {@link IO} implementation based on {@link Console}. */
-class ConsoleIO implements IO {
-    private final @Nullable Console console = System.console();
+    private final IO delegate;
+
+    public DelegatingIO(IO delegate) {
+        if (System.console() == null) this.delegate = new SystemInOutIO();
+        else this.delegate = delegate;
+    }
 
     @Override
     public @Nullable String readLine() {
-        if (console == null)
-            throw new IllegalStateException("Use another implementation of interface IO");
-        return console.readLine();
+        return delegate.readLine();
     }
 
     @Override
     public @Nullable String readLine(String prompt) {
-        printf(prompt);
-        return readLine();
+        return delegate.readLine(prompt);
+    }
+
+    @Override
+    public @Nullable String readLine(String promptFormat, Object... args) {
+        return delegate.readLine(promptFormat, args);
     }
 
     @Override
     public void printf(String format, Object... args) {
-        if (console == null)
-            throw new IllegalStateException("Use another implementation of interface IO");
-        console.printf(format, args);
+        delegate.printf(format, args);
     }
 }

--- a/java/dev/enola/chat/SystemInOutIO.java
+++ b/java/dev/enola/chat/SystemInOutIO.java
@@ -18,18 +18,33 @@
 package dev.enola.chat;
 
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.Console;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 
-/** ConsoleIO is an {@link IO} implementation based on {@link Console}. */
-class ConsoleIO implements IO {
-    private final @Nullable Console console = System.console();
+/** SystemInOutIO is an {@link IO} implementation based on {@link System#in}. */
+class SystemInOutIO implements IO {
+    private static final Logger LOG = LoggerFactory.getLogger(SystemInOutIO.class);
+
+    // TODO Charset should not be hard-coded to defaultCharset, but ... from Context?
+
+    private final BufferedReader reader =
+            new BufferedReader(new InputStreamReader(System.in, Charset.defaultCharset()));
 
     @Override
     public @Nullable String readLine() {
-        if (console == null)
-            throw new IllegalStateException("Use another implementation of interface IO");
-        return console.readLine();
+        try {
+            var line = reader.readLine();
+            if (line != null) System.out.println(line); // echo!
+            return line;
+        } catch (IOException e) {
+            LOG.warn("readLine() from STDIN, without System.console(), failed", e);
+            return null;
+        }
     }
 
     @Override
@@ -40,8 +55,6 @@ class ConsoleIO implements IO {
 
     @Override
     public void printf(String format, Object... args) {
-        if (console == null)
-            throw new IllegalStateException("Use another implementation of interface IO");
-        console.printf(format, args);
+        System.out.printf(format, args);
     }
 }

--- a/java/dev/enola/chat/SystemInOutIOTest.java
+++ b/java/dev/enola/chat/SystemInOutIOTest.java
@@ -21,14 +21,14 @@ import static com.google.common.truth.Truth.assertThat;
 
 import org.junit.Test;
 
-public class ConsoleIOTest {
+public class SystemInOutIOTest {
 
     @Test
     public void stdin() {
         SystemStdinStdoutTester.pipeIn(
                 "hello\nworld\nend", // Intentionally no last \n at the end!
                 () -> {
-                    IO io = new DelegatingIO(new ConsoleIO());
+                    IO io = new SystemInOutIO();
                     assertThat(io.readLine()).isEqualTo("hello");
                     assertThat(io.readLine()).isEqualTo("world");
                     assertThat(io.readLine()).isEqualTo("end");
@@ -41,7 +41,7 @@ public class ConsoleIOTest {
                 SystemStdinStdoutTester.captureOut(
                         () -> {
                             System.out.println("hello");
-                            IO io = new DelegatingIO(new ConsoleIO());
+                            IO io = new SystemInOutIO();
                             io.printf("world");
                         });
         assertThat(out).isEqualTo("hello\nworld");

--- a/java/dev/enola/chat/SystemStdinStdoutTester.java
+++ b/java/dev/enola/chat/SystemStdinStdoutTester.java
@@ -18,6 +18,7 @@
 package dev.enola.chat;
 
 import java.io.*;
+import java.nio.charset.Charset;
 
 public class SystemStdinStdoutTester {
 
@@ -25,10 +26,12 @@ public class SystemStdinStdoutTester {
 
     // TODO combinations of System.in, System.out, System.err
 
+    // TODO Rethink Charset... should be a constructor argument?!
+
     public static void pipeIn(String input, Runnable runnable) {
         InputStream original = System.in;
         try {
-            System.setIn(new ByteArrayInputStream(input.getBytes(ConsoleIO.consoleCharset())));
+            System.setIn(new ByteArrayInputStream(input.getBytes(consoleCharset())));
             runnable.run();
         } finally {
             System.setIn(original);
@@ -39,12 +42,17 @@ public class SystemStdinStdoutTester {
         var original = System.out;
         try {
             var out = new ByteArrayOutputStream();
-            var ps = new PrintStream(out, true, ConsoleIO.consoleCharset());
+            var ps = new PrintStream(out, true, consoleCharset());
             System.setOut(ps);
             runnable.run();
-            return out.toString(ConsoleIO.consoleCharset());
+            return out.toString(consoleCharset());
         } finally {
             System.setOut(original);
         }
+    }
+
+    private static Charset consoleCharset() {
+        if (System.console() != null) return System.console().charset();
+        return Charset.defaultCharset();
     }
 }

--- a/java/dev/enola/cli/ChatCommand.java
+++ b/java/dev/enola/cli/ChatCommand.java
@@ -17,6 +17,7 @@
  */
 package dev.enola.cli;
 
+import dev.enola.chat.DelegatingIO;
 import dev.enola.chat.Demo;
 import dev.enola.chat.jline.JLineIO;
 import dev.enola.common.context.TLC;
@@ -41,7 +42,7 @@ public class ChatCommand implements Callable<Integer> {
         var tbf = new ProxyTBF(ImmutableThing.FACTORY);
         try (var ctx = TLC.open()) {
             ctx.push(ThingIntoAppendableConverter.class, new JavaThingIntoRdfAppendableConverter());
-            Demo.chat(new JLineIO(), new Subjects(tbf).local());
+            Demo.chat(new DelegatingIO(new JLineIO()), new Subjects(tbf).local());
         }
         return 0;
     }


### PR DESCRIPTION
This will fix https://docs.enola.dev/use/chat/ to look like it used to again. (It was "broken" after #1320.)