### PR TITLE
docs: Fix ugly GitHub internal runner hostname on documentation

### DIFF
--- a/docs/use/chat/index.md
+++ b/docs/use/chat/index.md
@@ -27,7 +27,7 @@ Enola’s Chat is _The Shell for the 2030s+_ and the _“last Chat you'll ever n
 ## Usage
 
 ```bash cd ../.././..
-$ ./enola chat <docs/use/chat/demo.input
+$ HOSTNAME=demo ./enola chat <docs/use/chat/demo.input
 ...
 ```
 


### PR DESCRIPTION
Using `HOSTNAME=demo` will replace e.g.

    runner@fv-az1676-912.hgliqetka4nuhd5izdx202eusg.phxx.internal.cloudapp.net in #Lobby> /help

on https://docs.enola.dev/use/chat/ with:

    runner@demo in #Lobby> /help
