### PR TITLE
fix: Make EnolaAgent only run JLine commands which actually exist

### DIFF
--- a/java/dev/enola/chat/ExecAgent.java
+++ b/java/dev/enola/chat/ExecAgent.java
@@ -39,6 +39,10 @@ import java.util.*;
 
 public class ExecAgent extends AbstractAgent {
 
+    // TODO Must check if command is a path or on the PATH
+
+    // TODO If PATH contains "." then this won't really work yet as-is
+
     // TODO Offer tab completion of all available commands in Chat
     //   see https://jline.org/docs/tab-completion
 

--- a/java/dev/enola/cli/ChatCommand.java
+++ b/java/dev/enola/cli/ChatCommand.java
@@ -47,6 +47,7 @@ import picocli.shell.jline3.PicocliCommands;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 @CommandLine.Command(
@@ -101,6 +102,7 @@ public class ChatCommand implements Callable<Integer> {
     /** EnolaAgent runs Enola's own CLI sub-commands. */
     private static class EnolaAgent extends AbstractAgent {
         private final CommandLine picocliCommandLine;
+        private final Set<String> commands;
 
         public EnolaAgent(Switchboard pbx, CommandLine commandLine) {
             super(
@@ -111,6 +113,7 @@ public class ChatCommand implements Callable<Integer> {
                             .build(),
                     pbx);
             this.picocliCommandLine = commandLine;
+            this.commands = picocliCommandLine.getSubcommands().keySet();
         }
 
         @Override
@@ -120,7 +123,11 @@ public class ChatCommand implements Callable<Integer> {
             // Builtins), but don't re-use this as-is for other more complex external commands.
             var splitCommandLine = List.of(commandLine.split("\\s+"));
 
-            picocliCommandLine.execute(splitCommandLine.toArray(new String[0]));
+            var command = splitCommandLine.get(0);
+            if (!commands.contains(command)) return;
+
+            // TODO Do something with exit code (just like for exec, where it's also still ignored)
+            int exit = picocliCommandLine.execute(splitCommandLine.toArray(new String[0]));
         }
     }
 }

--- a/java/dev/enola/cli/ChatCommand.java
+++ b/java/dev/enola/cli/ChatCommand.java
@@ -26,7 +26,7 @@ import dev.enola.chat.Switchboard;
 import dev.enola.common.context.TLC;
 import dev.enola.common.linereader.SystemInOutIO;
 import dev.enola.common.linereader.jline.JLineAgent;
-import dev.enola.common.linereader.jline.JLineBuiltinShellCommandsProcessor;
+import dev.enola.common.linereader.jline.JLineBuiltinCommandsProcessor;
 import dev.enola.common.linereader.jline.JLineIO;
 import dev.enola.common.secret.InMemorySecretManager;
 import dev.enola.identity.Subject;
@@ -67,7 +67,7 @@ public class ChatCommand implements Callable<Integer> {
                 try (var terminal = TerminalBuilder.terminal()) {
                     var parentCommandLine = spec.commandLine().getParent();
                     var picocliCommands = new PicocliCommands(parentCommandLine);
-                    var builtinCmdsProcessor = new JLineBuiltinShellCommandsProcessor(terminal);
+                    var builtinCmdsProcessor = new JLineBuiltinCommandsProcessor(terminal);
                     var cwdSupplier = builtinCmdsProcessor.cwdSupplier();
                     SystemRegistry systemRegistry =
                             new SystemRegistryImpl(parser, terminal, cwdSupplier, null);

--- a/java/dev/enola/common/linereader/jline/Demo.java
+++ b/java/dev/enola/common/linereader/jline/Demo.java
@@ -25,7 +25,7 @@ public class Demo {
 
     public static void main(String[] args) throws Exception {
         try (var terminal = TerminalBuilder.terminal()) {
-            var consumer = new JLineBuiltinShellCommandsProcessor(terminal);
+            var consumer = new JLineBuiltinCommandsProcessor(terminal);
             var tailTips = consumer.commandDescriptions();
             try (var jLineIO =
                     new JLineIO(

--- a/java/dev/enola/common/linereader/jline/JLineAgent.java
+++ b/java/dev/enola/common/linereader/jline/JLineAgent.java
@@ -28,9 +28,9 @@ import org.slf4j.Logger;
 public class JLineAgent extends AbstractAgent {
     private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(JLineAgent.class);
 
-    private final JLineBuiltinShellCommandsProcessor proc;
+    private final JLineBuiltinCommandsProcessor proc;
 
-    public JLineAgent(Switchboard pbx, JLineBuiltinShellCommandsProcessor proc) {
+    public JLineAgent(Switchboard pbx, JLineBuiltinCommandsProcessor proc) {
         super(
                 tbf.create(Subject.Builder.class, Subject.class)
                         .iri("https://jline.org")

--- a/java/dev/enola/common/linereader/jline/JLineBuiltinCommandsProcessor.java
+++ b/java/dev/enola/common/linereader/jline/JLineBuiltinCommandsProcessor.java
@@ -37,8 +37,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-public class JLineBuiltinShellCommandsProcessor implements CheckedConsumer<String, Exception> {
-    // TODO Rename JLineBuiltinShellCommandsProcessor to JLineBuiltinCommandsProcessor
+public class JLineBuiltinCommandsProcessor implements CheckedConsumer<String, Exception> {
 
     // TODO https://github.com/jline/jline3/issues/1256
 
@@ -49,7 +48,7 @@ public class JLineBuiltinShellCommandsProcessor implements CheckedConsumer<Strin
     private final Supplier<Path> cwdSupplier;
     private @Nullable LineReader lineReader;
 
-    public JLineBuiltinShellCommandsProcessor(Terminal terminal) {
+    public JLineBuiltinCommandsProcessor(Terminal terminal) {
         commandSession = new Builtins.CommandSession(terminal);
         // TODO Integrate with cwd in ExecAgent - but keep Optional!
         this.cwdSupplier = () -> null; // Path.of("/");


### PR DESCRIPTION
This will fix the mess that's currently show on https://docs.enola.dev/use/chat/ again.