### PR TITLE
fix: Slf4jLoggingConsumer uses specific Logger

### DIFF
--- a/java/dev/enola/ai/mcp/McpLoader.java
+++ b/java/dev/enola/ai/mcp/McpLoader.java
@@ -124,7 +124,7 @@ public class McpLoader implements NamedTypedObjectProvider<McpSyncClient> {
                         // TODO Make this configurable - but how & from where?
                         // .initializationTimeout(Duration.ofSeconds(7))
                         // .requestTimeout(Duration.ofSeconds(7))
-                        .loggingConsumer(new McpServer(origin))
+                        .loggingConsumer(new Slf4jLoggingConsumer(origin))
                         .build();
         client.initialize();
         client.ping();

--- a/java/dev/enola/ai/mcp/Slf4jLoggingConsumer.java
+++ b/java/dev/enola/ai/mcp/Slf4jLoggingConsumer.java
@@ -26,19 +26,22 @@ import org.slf4j.event.Level;
 
 import java.util.function.Consumer;
 
-class McpServer implements Consumer<LoggingMessageNotification> {
+class Slf4jLoggingConsumer implements Consumer<LoggingMessageNotification> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(McpServer.class);
+    // TODO: If https://github.com/modelcontextprotocol/java-sdk/pull/503
+    //   is accepted and merged, the eventually replace this by that?
+    //   But that doesn't have the origin... hm. Add it?
 
     private final String origin;
 
-    public McpServer(String origin) {
+    public Slf4jLoggingConsumer(String origin) {
         this.origin = origin;
     }
 
     @Override
     public void accept(LoggingMessageNotification notif) {
-        LOG.atLevel(convert(notif.level()))
+        Logger log = LoggerFactory.getLogger(notif.logger());
+        log.atLevel(convert(notif.level()))
                 .log("{} : {} : {}", origin, notif.logger(), notif.data());
     }
 


### PR DESCRIPTION
See also https://github.com/modelcontextprotocol/java-sdk/pull/503

and https://github.com/google/adk-java/pull/370.