### PR TITLE
feat: MCP 🔱 Memory 🧠

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -41,7 +41,6 @@ indent_size = unset
 
 [*.json]
 max_line_length = unset
-max_line_length = unset
 
 [*.jsonc]
 max_line_length = unset
@@ -92,13 +91,7 @@ insert_final_newline = false
 indent_size = unset
 max_line_length = unset
 
-[mkdocs.yaml]
-max_line_length = unset
-
 [WORKSPACE.bazel]
-max_line_length = unset
-
-[ci.yaml]
 max_line_length = unset
 
 [CITATION.cff]
@@ -111,9 +104,6 @@ max_line_length = unset
 [jbang*]
 max_line_length = unset
 
-[pnpm-lock.yaml]
-max_line_length = unset
-
 [bun.lock]
 max_line_length = unset
 
@@ -122,6 +112,10 @@ max_line_length = unset
 insert_final_newline = unset
 
 [.deepsource.toml]
+max_line_length = unset
+
+[*.yaml]
+indent_size = unset
 max_line_length = unset
 
 # Note that https://github.com/editorconfig-checker/editorconfig-checker

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,6 +96,12 @@ jobs:
           # NB: Repeated below in push-container-image: job; must keep in sync!
           java-version: "21"
 
+      # This must ALWAYS run AFTER actions/setup-java, due to https://github.com/google/google-java-format/pull/1228/files.
+      - name: pre-commit run --all-files
+        uses: flox/activate-action@v1
+        with:
+          command: pre-commit run --all-files
+
       # TODO Explore further how to appropriately use "env -i" isolation to see failure locally (due to missing protoc, at this stage, while still with AFDS, before Flox)
       # TODO Remove this duplication; normally this only runs at the end, only here to debug:
       # This must ALWAYS run AFTER actions/setup-java, due to https://github.com/google/google-java-format/pull/1228/files.
@@ -195,8 +201,7 @@ jobs:
       - name: tools/git/test.bash
         run: tools/git/test.bash
 
-      # Any "dirty" changes will cause build to abort. This intentionally runs after the build.
-      # This must ALWAYS run AFTER actions/setup-java, due to https://github.com/google/google-java-format/pull/1228/files.
+      # Any "dirty" changes will cause build to abort. This intentionally runs again after the build.
       - name: pre-commit run --all-files
         uses: flox/activate-action@v1
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -147,12 +147,14 @@ repos:
       - id: buildifier-lint
         args: *args
 
+  # TODO Replace, because it's archived=unmaintained ("prettier made some changes that breaks plugins entirely")
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
         # NOT markdown, because we use markdownlint for that
-        types_or: [css, html, javascript, json, json5, scss, ts, tsx, yaml]
+        # NOT YAML, because ... it suddenly, and without version change (?!) wanted to change them all
+        types_or: [css, html, javascript, json, json5, scss, ts, tsx]
         exclude: ^docs/use|test/|.devcontainer/devcontainer.json|third_party/
         additional_dependencies:
           # TODO Avoid duplicating the Prettier version here and in web/package.json

--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -46,3 +46,7 @@ Name ("nick") of agent. Typically, it's set automatically by a loader from a por
 ## Tools
 
 [Tools](tool.md) to which the agent has access, including [MCP](mcp.md).
+
+## TODO
+
+_Agents will soon allow configuring parallel (or sequential) and "looped" execution of other agents!_

--- a/docs/concepts/mcp.md
+++ b/docs/concepts/mcp.md
@@ -45,9 +45,6 @@ MCP servers are only started (or connected to), and queried for their 🧰 Tools
 
     TODO
 
-    Filesystem!
-    Memory...
-        https://github.com/modelcontextprotocol/servers/tree/main/src/memory
     Zapier
     Google Mail & Calendar & Drive!
     RAG with Pinecone, LlamaIndex?
@@ -60,6 +57,10 @@ MCP servers are only started (or connected to), and queried for their 🧰 Tools
 
 ### Fetch
 
+```yaml
+{% include "../../test/agents/fetch.agent.yaml" %}
+```
+
 The [`fetch` MCP server](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch) can fetch a webpage, and extract its contents as Markdown:
 
 ```shell
@@ -71,17 +72,45 @@ Exercise caution when using this MCP server to ensure this does not expose any s
 
 ### Filesystem
 
+```yaml
+{% include "../../test/agents/filesystem.agent.yaml" %}
+```
+
 ```shell
 enola ai -a test/agents/filesystem.agent.yaml --in="list the files in $PWD"
 ```
 
 ### Git
 
+```yaml
+{% include "../../test/agents/git.agent.yaml" %}
+```
+
 ```shell
-enola ai --agents=test/agents/git.agent.yaml --in "Write a proposed commit message for the uncommited files in $PWD"
+enola ai --agents=test/agents/git.agent.yaml --in "Write a proposed commit message for the uncommitted files in $PWD"
 ```
 
 CAUTION: This server is inherently insecure; you should carefully evaluate if it meets your needs.
+
+### Memory
+
+```yaml
+{% include "../../test/agents/memory.agent.yaml" %}
+```
+
+[Memory](https://github.com/modelcontextprotocol/servers/tree/main/src/memory) can remember things:
+
+```shell
+$ enola -vv ai --agents=test/agents/memory.agent.yaml --in "John Smith is a person who speaks fluent Spanish."
+I have noted that John Smith is a person who speaks fluent Spanish.
+```
+
+`cat ~/memory.json` let's you see the memory 🧠 cells! 😝 Now, perhaps another day:
+
+```shell
+$ enola -v ai --agents=test/agents/memory.agent.yaml --in "Does John Smith speak Italian?"
+Remembering...Based on my memory, John Smith speaks fluent Spanish. I do not have any information indicating that he speaks Italian.
+```
 
 ### Everything
 

--- a/docs/use/mcp/index.md
+++ b/docs/use/mcp/index.md
@@ -20,7 +20,7 @@
 
 `mcp` has useful commands for exploring [MCP Tools](../../concepts/mcp.md).
 
-This is similar to the [MCP Inspector](https://github.com/modelcontextprotocol/inspector), and other such tools
+This is similar to the [MCP Inspector](https://github.com/modelcontextprotocol/inspector), and other such tools.
 
 ## Call MCP Tool
 

--- a/java/dev/enola/ai/mcp/McpServerStdErrLogConsumer.java
+++ b/java/dev/enola/ai/mcp/McpServerStdErrLogConsumer.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2025 The Enola <https://enola.dev> Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.enola.ai.mcp;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.function.Consumer;
+
+class McpServerStdErrLogConsumer implements Consumer<String> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(McpServerStdErrLogConsumer.class);
+
+    private final String origin;
+
+    public McpServerStdErrLogConsumer(String origin) {
+        this.origin = origin;
+    }
+
+    @Override
+    public void accept(String stdErr) {
+        LOG.warn("{} : {}", origin, stdErr);
+    }
+}

--- a/models/enola.dev/ai/mcp.yaml
+++ b/models/enola.dev/ai/mcp.yaml
@@ -36,6 +36,15 @@ servers:
     args: [mcp-server-fetch]
     origin: https://github.com/modelcontextprotocol/servers/tree/main/src/fetch
 
+  modelcontextprotocol/memory:
+    command: npx
+    args: [-y, "@modelcontextprotocol/server-memory"]
+    origin: https://github.com/modelcontextprotocol/servers/tree/main/src/memory
+    log: debug
+    env:
+      # TODO Support ~ and $HOME expansion
+      MEMORY_FILE_PATH: /home/vorburger/memory.json
+
   modelcontextprotocol/everything:
     command: npx
     args: [-y, "@modelcontextprotocol/server-everything"]

--- a/test/agents/memory.agent.yaml
+++ b/test/agents/memory.agent.yaml
@@ -1,0 +1,28 @@
+$schema: https://enola.dev/ai/agent
+model: google://?model=gemini-2.5-flash
+instruction: >
+  Follow these steps for each interaction:
+
+  1. User Identification:
+     - You should assume that you are interacting with default_user
+     - If you have not identified default_user, proactively try to do so.
+
+  2. Memory Retrieval:
+     - Always begin your chat by saying only "Remembering..." and retrieve all relevant information from your knowledge graph
+     - Always refer to your knowledge graph as your "memory"
+
+  3. Memory
+     - While conversing with the user, be attentive to any new information that falls into these categories:
+       a) Basic Identity (age, gender, location, job title, education level, etc.)
+       b) Behaviors (interests, habits, etc.)
+       c) Preferences (communication style, preferred language, etc.)
+       d) Goals (goals, targets, aspirations, etc.)
+       e) Relationships (personal and professional relationships up to 3 degrees of separation)
+
+  4. Memory Update:
+     - If any new information was gathered during the interaction, update your memory as follows:
+       a) Create entities for recurring organizations, people, and significant events
+       b) Connect them to the current entities using relations
+       c) Store facts about them as observations
+tools:
+  - modelcontextprotocol/memory


### PR DESCRIPTION
The Memory MCP server has been integrated, allowing agents to store and retrieve information. This involved adding McpServerStdErrLogConsumer.java` to capture `stderr` from MCP servers for better debugging, and updating McpLoader.java` to utilize this new consumer. The `models/enola.dev/ai/mcp.yaml` was updated to include the configuration for the `modelcontextprotocol/memory` server, and a new `test/agents/memory.agent.yaml` was added to demonstrate its usage.

Documentation has been significantly updated in `docs/concepts/mcp.md` to include comprehensive examples for the `fetch`, `filesystem`, `git`, and the newly added `memory` MCP servers, making it easier for users to understand and utilize these capabilities. Additionally, `docs/concepts/agent.md` includes a new TODO regarding future parallel/sequential agent execution, and `docs/use/mcp/index.md` received a minor formatting fix.

The `.editorconfig` file was also revised to improve consistency across different file types, including more general rules for YAML files and adjustments for `max_line_length` and `insert_final_newline` in specific file patterns.

---
New thoughts take hold,
Memory's embrace so warm,
Docs now truly shine.