### PR TITLE
docs: Update JBang installation and usage instructions 📝✨

### DIFF
--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -66,11 +66,14 @@ are not accessible to the container ("by design").
 
 ## JBang
 
-From [our Maven repo](../dev/maven.md), using [JBang](https://www.jbang.dev/):
+After [installing JBang](https://www.jbang.dev/download/), do:
 
-    jbang --repos https://docs.enola.dev/maven-repo/,mavencentral,jitpack --main=dev.enola.cli.EnolaApplication dev.enola:enola:0.0.1-SNAPSHOT
+    jbang app install enola@enola-dev
+
+You can now run Enola with:
+
+    enola --help
 
 <!-- TODO Make this work... it doesn't quite, yet:
-
-    jbang --repos https://docs.enola.dev/maven-repo/,mavencentral,jitpack --main=dev.enola.cli.EnolaApplication dev.enola:enola:0.0.1-SNAPSHOT server --chatPort=7070 --lm="google://?model=gemini-2.5-flash" --http-scheme --agents=https://raw.githubusercontent.com/enola-dev/enola/refs/heads/main/test/agents/chef-optimist.agent.yam
+    enola server --chatPort=7070 --lm="google://?model=gemini-2.5-flash" --http-scheme --agents=https://raw.githubusercontent.com/enola-dev/enola/refs/heads/main/test/agents/chef-optimist.agent.yam
 -->

--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -75,5 +75,5 @@ You can now run Enola with:
     enola --help
 
 <!-- TODO Make this work... it doesn't quite, yet:
-    enola server --chatPort=7070 --lm="google://?model=gemini-2.5-flash" --http-scheme --agents=https://raw.githubusercontent.com/enola-dev/enola/refs/heads/main/test/agents/chef-optimist.agent.yam
+    enola server --chatPort=7070 --lm="google://?model=gemini-2.5-flash" --http-scheme --agents=https://raw.githubusercontent.com/enola-dev/enola/refs/heads/main/test/agents/chef-optimist.agent.yaml
 -->


### PR DESCRIPTION
The `docs/use/index.md` file was updated to reflect the new, streamlined JBang installation method using `jbang app install enola@enola-dev`. This change simplifies the setup process for users, replacing the previous, more verbose `jbang` command that required explicit repository flags. Additionally, the documentation now includes a clear example of how to run Enola using `enola --help` after installation.

---
JBang now simpler,
Docs updated, clear the path,
Enola ready.

Relates to | Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] `./test.bash` passes locally
- [ ] Appropriate changes to documentation are included in the PR

fixes: #1625
