### PR TITLE
deps: Bump ADK Java to latest current commit rev

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@
 # not the bazel_dep, or vice versa, leading to inconsistencies (see
 # https://github.com/VirtusLab/bazel-steward/issues/404).
 
-ADK_JAVA_COMMIT = "806e985805ae47bfdf6931f02d12f928a0f3bcc8"
+ADK_JAVA_COMMIT = "eb232ee780c986bfdbae708882c7766854bba5d5"
 
 RDF4J_VERSION = "5.1.4"
 


### PR DESCRIPTION
This should help with #1627 (TBC).

Pending completion of (currently running) https://jitpack.io/com/github/google/adk-java/eb232ee780/build.log ...