### PR TITLE
feat: ✨ Introduce Agent Output Schema support! 📝

### DIFF
--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -43,7 +43,13 @@ One-line description of the agent's capability. The model uses this to determine
 
 Name ("nick") of agent. Typically, it's set automatically by a loader from a portion of the origin URL. <!-- This is just a recommendation, and a loader could change it if another agent (with another ID) already uses this name. Users can also change the nicknames of their agents. -->
 
-## Tools
+### Output Schema
+
+The `output.schema` allows specifying the expected structure of the output from the agent in JSON Schema.
+
+The [`person.agent.yaml`](https://github.com/enola-dev/enola/blob/main/test/agents/person.agent.yaml) example illustrates how to use this.
+
+### Tools
 
 [Tools](tool.md) to which the agent has access, including [MCP](mcp.md).
 

--- a/java/dev/enola/ai/dotagent/BUILD
+++ b/java/dev/enola/ai/dotagent/BUILD
@@ -79,5 +79,6 @@ junit_tests(
         "//java/dev/enola/common/secret",
         "//java/dev/enola/common/secret/auto",
         "//test",
+        "@enola_maven//:com_github_google_adk_java_google_adk",
     ],
 )

--- a/java/dev/enola/ai/dotprompt/DotPrompt.java
+++ b/java/dev/enola/ai/dotprompt/DotPrompt.java
@@ -88,12 +88,8 @@ public class DotPrompt extends WithSchema {
     /** Defines the (schema of the) input variables the prompt. */
     public @Nullable Input input;
 
-    // TODO public Optional<Schema> inputSchema();
-
     /** Defines the expected model output format. */
     public @Nullable Output output;
-
-    // TODO public Optional<Schema> outputSchema();
 
     /**
      * Template of Prompt, as text.
@@ -123,6 +119,8 @@ public class DotPrompt extends WithSchema {
          */
         // TODO Validate by parsing with JSON Schema parser, not (just) text to basic JSON Map
         public final Map<String, Object> schema = new HashMap<>();
+
+        // TODO public @Nullable URI schemaRef;
     }
 
     public static class Output {
@@ -132,7 +130,10 @@ public class DotPrompt extends WithSchema {
             text
         }
 
-        /** Desired output format for this prompt. */
+        /**
+         * Desired output format for this prompt. Implicitly set to JSON if the schema is specified.
+         */
+        // TODO Remove? ADK doesn't seem to support this; it just has LlmAgent.outputSchema(Schema)
         public Format format = Format.text;
 
         /**
@@ -141,5 +142,9 @@ public class DotPrompt extends WithSchema {
          */
         // TODO Validate by parsing with JSON Schema parser, not (just) text to basic JSON Map
         public final Map<String, Object> schema = new HashMap<>();
+
+        // TODO public @Nullable URI schemaRef;
+
+        // TODO public @Nullable String outputKey;
     }
 }

--- a/java/dev/enola/ai/dotprompt/adk/DotPrompt2LlmAgent.java
+++ b/java/dev/enola/ai/dotprompt/adk/DotPrompt2LlmAgent.java
@@ -61,6 +61,9 @@ public class DotPrompt2LlmAgent {
     }
 
     public BaseAgent convert(DotPrompt dotPrompt) throws IOException {
+        // TODO Share this code with ADK AgentsLoader !!
+        //   Actually, DotPrompt may soon be completely abandoned, in favour of DotAgent ..
+
         var model = llmProvider.get(dotPrompt.model, dotPrompt.id);
         var llmAgentBuilder = LlmAgent.builder().name(dotPrompt.name).model(model);
 
@@ -68,6 +71,7 @@ public class DotPrompt2LlmAgent {
         //   TODO llmAgentBuilder.instruction( ? )
         //   TODO llmAgentBuilder.globalInstruction( ? )
 
+        // TODO Validate both input & output JSON Schemas!!
         if (dotPrompt.input != null) llmAgentBuilder.inputSchema(schema(dotPrompt.input.schema));
         if (dotPrompt.output != null) llmAgentBuilder.outputSchema(schema(dotPrompt.output.schema));
 

--- a/java/dev/enola/ai/iri/ModelConfig.java
+++ b/java/dev/enola/ai/iri/ModelConfig.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class ModelConfig {
 
-    // TODO Also `seed`, `stopSequences` ?
+    // TODO Also `thinking`, `maxSteps`, `seed`, `stopSequences` ?
 
     private Optional<Double> temperature = Optional.empty();
     private Optional<Double> topP = Optional.empty();

--- a/test/agents/person.agent.yaml
+++ b/test/agents/person.agent.yaml
@@ -1,0 +1,25 @@
+# Origin: https://github.com/google/dotprompt#example-prompt-file
+$schema: https://enola.dev/ai/agent
+model: google://?model=gemini-2.5-flash&temperature=0
+instruction:
+  Extract the requested information from the given text.
+  If a piece of information is not present, omit that field from the output.
+output:
+  # TODO schemaRef: person.schema.yaml
+  schema:
+    type: object
+    properties:
+      name:
+        type: string
+        description: the full name of the person
+      age:
+        type: number
+        description: the age of the person
+      occupation:
+        type: string
+        description: the person's occupation
+
+#test:
+#    text: John Doe is a 35-year-old software engineer living in Zürich.
+#    expected:
+#        equals: { "name": "John Doe", "age": 35, "occupation": "software engineer" }

--- a/test/agents/person.schema.yaml
+++ b/test/agents/person.schema.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2025 The Enola <https://enola.dev> Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+$schema: https://json-schema.org/draft/2020-12/schema
+
+type: object
+properties:
+  name:
+    type: string
+    description: the full name of the person
+  age:
+    type: number
+    description: the age of the person
+  occupation:
+    type: string
+    description: the person's occupation


### PR DESCRIPTION
This commit introduces the highly anticipated support for specifying an `output.schema` directly within agent definitions. This empowers agents to define and enforce the structure of their generated output using JSON Schema, leading to more predictable and machine-readable responses.

The `AgentsLoader.java` now correctly parses and applies the `output.schema` defined in agent configurations, converting the schema map into a usable ADK `Schema` object. To illustrate and validate this new functionality, a new `person.agent.yaml` and its corresponding `person.schema.yaml` have been added under `test/agents/`. These demonstrate how to define an agent that extracts structured information about a person. An integration test in `AgentsLoaderIntegrationTest.java` ensures the agent correctly produces JSON output conforming to the specified schema.

Documentation in `docs/concepts/agent.md` has been updated to reflect this new capability, guiding users on how to leverage output schemas for their agents. Minor refactorings in `AgentsLoaderIntegrationTest.java` streamline agent loading for tests, and dependency updates in `java/dev/enola/ai/dotagent/BUILD` support the new ADK schema handling.

---
Schema guides output,
Agent crafts data with care,
Structured insights bloom.