### PR TITLE
chore: Use `npm ci` instead of `npm install`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "enola",
       "dependencies": {
         "svg-term-cli": "^2.1.1"
       }

--- a/tools/docs/build.bash
+++ b/tools/docs/build.bash
@@ -44,7 +44,7 @@ find docs/ -type f -name "*.md" -print0 \
 # we're then skipping it below, because this is quick, and doing it anyway helps
 # to detecting any CI build system regression with Nix etc.
 if ! [ -f "node_modules/.bin/svg-term" ]; then
-  npm install svg-term-cli
+  npm ci
 fi
 PATH="$(pwd)/node_modules/.bin:$PATH"
 export PATH


### PR DESCRIPTION
Relates to #1655.