### PR TITLE
fix: maven/install must use enola/... 

### DIFF
--- a/tools/maven/install.bash
+++ b/tools/maven/install.bash
@@ -19,7 +19,7 @@ set -euox pipefail
 
 # This installs the Maven Artifacts into a local repository...
 
-bazelisk build //java/dev/enola
+bazelisk build //java/dev/enola/...
 
 tools/javadoc/build.bash
 


### PR DESCRIPTION
so that enola:enola-pom, enola:enola-maven-source, enola:enola-maven-artifact etc. get built