### PR TITLE
chore: Run pre-commit under nix develop

### DIFF
--- a/test.bash
+++ b/test.bash
@@ -23,17 +23,18 @@ set -euo pipefail
 # Abort if there are any broken symlinks
 (find . -xtype l -ls | grep .) && exit 1
 
-# Similar also in the ./enola script:
-GO_BIN_PATH=$(go env GOPATH)/bin
-BZL=$GO_BIN_PATH/bazelisk
-if ! [ -x "$(command -v "$BZL")" ]; then
-  if [ -x "$(command -v go)" ]; then
+if command -v bazelisk &> /dev/null; then
+  BZL=bazelisk
+else
+  if ! command -v go &> /dev/null; then
+    echo "Error: 'go' command not found, and 'bazelisk' is not in PATH." >&2
+    echo "Please install Go (see https://go.dev/doc/install) or set up your environment with Nix." >&2
+    exit 1
+  fi
+  GO_BIN_PATH=$(go env GOPATH)/bin
+  BZL=$GO_BIN_PATH/bazelisk
+  if ! [ -x "$BZL" ]; then
     tools/go/install.bash
-
-  else
-    echo "Please install Go from https://go.dev/doc/install and re-run this script!"
-    echo "See also https://docs.enola.dev/dev/setup/"
-    exit 255
   fi
 fi
 

--- a/tools/git/hooks/pre-commit
+++ b/tools/git/hooks/pre-commit
@@ -1,2 +1,26 @@
-echo .git/hooks/pre-commit runs ./test.bash...
-./test.bash
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2023-2025 The Enola <https://enola.dev> Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -euo pipefail
+
+if command -v nix &> /dev/null; then
+    echo ".git/hooks/pre-commit now runs ./test.bash inside a 'nix develop' environment..."
+    nix develop --ignore-env --keep-env-var HOME --keep-env-var TERM --command ./test.bash
+
+else
+    echo ".git/hooks/pre-commit now runs ./test.bash directly - without Nix; see https://docs.enola.dev/dev/setup"
+    ./test.bash
+fi

--- a/tools/git/install-hooks.bash
+++ b/tools/git/install-hooks.bash
@@ -19,7 +19,4 @@ set -euo pipefail
 
 DIR=$(realpath "$(dirname "$0")")
 
-if ! [ -e "$DIR/../../.git/hooks/pre-commit" ]; then
-  cp -v "$DIR/hooks/"* "$DIR/../../.git/hooks/"
-  chmod +x "$DIR/../../.git/hooks/"*
-fi
+ln --force --symbolic --relative "$DIR/hooks/"* "$DIR/../../.git/hooks/"

--- a/tools/go/install.bash
+++ b/tools/go/install.bash
@@ -17,6 +17,12 @@
 
 set -euox pipefail
 
+if ! command -v go &> /dev/null; then
+  echo "Please install Go from https://go.dev/doc/install and re-run this script!"
+  echo "See also https://docs.enola.dev/dev/setup/"
+  exit 255
+fi
+
 # This script install pre-requisite go tools
 echo "$PATH"
 GO_BIN_PATH=$(go env GOPATH)/bin


### PR DESCRIPTION
@dotdoom agreed that this makes sense?

PS: There are [other ways](https://github.com/cachix/git-hooks.nix), but at least for now to start this seem like a useful quick win (which I need because I would like to run tools that are available only on Nix in pre-commit).