### PR TITLE
Add missing enola --version in Nix build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,7 @@
 
   outputs =
     {
+      self,
       nixpkgs,
       nixpkgs-bun,
       flake-utils,
@@ -46,6 +47,9 @@
 
           pkgs-bun.bun
         ];
+        # NB: This doesn't actually use tools/version/version-out.bash (like the non-Nix build does)
+        gitRev = toString (self.shortRev or self.dirtyShortRev or self.lastModified or "DEVELOPMENT");
+
       in
       {
         # TODO: for https://nix-bazel.build, replace with mkShellNoCC.
@@ -75,7 +79,7 @@
           default = enola;
           enola = pkgs.stdenv.mkDerivation {
             pname = "enola";
-            version = "0.0.1"; # TODO: read from file
+            version = gitRev;
 
             buildInputs = [ jdk' ];
             nativeBuildInputs = buildTools ++ [
@@ -85,6 +89,9 @@
             src = ./.;
 
             buildPhase = ''
+              # class dev.enola.common.Version reads VERSION
+              echo -n "${gitRev}" >tools/version/VERSION
+
               export HOME=$TMPDIR
               bazelisk build //java/dev/enola/cli:enola_deploy.jar
             '';

--- a/tools/version/version-out.bash
+++ b/tools/version/version-out.bash
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2023-2025 The Enola <https://enola.dev> Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# Inspired e.g. by https://github.com/palantir/gradle-git-version
+
+VERSION=$(git describe --tags --always --first-parent)
+VERSION=${VERSION%$'\n'}
+
+# Check for uncommitted files (that are not in .gitignore)
+# Beware that this could cause too frequent rebuilds during development while commiting;
+# but it's fine here because we only get this far if we are not on $CI anyway, so all good.
+if [ -n "$(git status --porcelain)" ]; then
+  VERSION="${VERSION}.dirty"
+fi
+
+echo "$VERSION"

--- a/tools/version/version-out.bash
+++ b/tools/version/version-out.bash
@@ -26,7 +26,8 @@ VERSION=${VERSION%$'\n'}
 # Beware that this could cause too frequent rebuilds during development while commiting;
 # but it's fine here because we only get this far if we are not on $CI anyway, so all good.
 if [ -n "$(git status --porcelain)" ]; then
-  VERSION="${VERSION}.dirty"
+  # Use -dirty instead of .dirty so that it's in the same format as Nix's self.dirtyShortRev
+  VERSION="${VERSION}-dirty"
 fi
 
 echo "$VERSION"

--- a/tools/version/version.bash
+++ b/tools/version/version.bash
@@ -17,8 +17,6 @@
 
 set -euo pipefail
 
-# Inspired e.g. by https://github.com/palantir/gradle-git-version
-
 # This is a PITA (!) during development, because every change and commit on //web/
 # triggers a full rebuild of //java/. We therefore now only run this on CI:
 if [ -z "${CI:-""}" ]; then
@@ -30,15 +28,7 @@ fi
 # because Bazel (also?) looks at the timestamp of the file to determine if it needs
 # to rebuild, not ([only?] a hash of) its content.
 
-NEW_VERSION=$(git describe --tags --always --first-parent)
-NEW_VERSION=${NEW_VERSION%$'\n'}
-
-# Check for uncommitted files (that are not in .gitignore)
-# Beware that this could cause too frequent rebuilds during development while commiting;
-# but it's fine here because we only get this far if we are not on $CI anyway, so all good.
-if [ -n "$(git status --porcelain)" ]; then
-  NEW_VERSION="${NEW_VERSION}.dirty"
-fi
+NEW_VERSION=$(tools/version/version-out.bash)
 
 if [ ! -f tools/version/VERSION ] || [ "$(cat tools/version/VERSION)" != "$NEW_VERSION" ]; then
   echo -n "$NEW_VERSION" > tools/version/VERSION


### PR DESCRIPTION
Relates #1654.

This makes e.g. `nix run --no-sandbox . -- -V` show the Git revision.

Thanks https://github.com/NixOS/nix/issues/4682.

@dotdoom PTAL - OK for you?