### PR TITLE
chore: nix fmt (re. #1711)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -121,6 +121,8 @@
             }/bin/test";
           };
         };
+
+        formatter = pkgs.nixfmt-tree;
       }
     );
 }

--- a/tools/test-ci/test.bash
+++ b/tools/test-ci/test.bash
@@ -21,6 +21,7 @@ set -euox pipefail
 
 # Nix specific non-regression test coverage
 nix develop -c echo "✅ Nix Dev shell works!"
+nix flake check
 nix run .#test
 
 # Run ./test.bash after models/build.bash, because this also runs pre-commit, which validates stuff using the generated JSON Schemas


### PR DESCRIPTION
Relates to #1711.

This fixes `nix fmt` (which is separate from what the just merged #1723 did).

Illustrates https://github.com/NixOS/nixfmt/issues/336.