### PR TITLE
clean: Avoid build WARNING

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,6 +24,9 @@ RDF4J_VERSION = "5.1.4"
 
 GRPC_JAVA_VERSION = "1.75.0"
 
+# https://github.com/bazel-contrib/rules_jvm_external/issues/1426
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+
 # see ./tools/java_toolchain/BUILD
 # see https://github.com/bazelbuild/bazel/issues/20877, NB the "_definition" suffix!
 register_toolchains("//tools/java_toolchain:repository_default_java_toolchain_definition")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -45,7 +45,8 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/MODULE.bazel": "8fdee2dbaace6c252131c00e1de4b165dc65af02ea278476187765e1a617b917",
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
-    "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/source.json": "f121b43eeefc7c29efbd51b83d08631e2347297c95aac9764a701f2a6a2bb953",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/MODULE.bazel": "88ade7293becda963e0e3ea33e7d54d3425127e0a326e0d17da085a5f1f03ff6",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/source.json": "7ebaefba0b03efe59cac88ed5bbc67bcf59a3eff33af937345ede2a38b2d368a",
     "https://bcr.bazel.build/modules/boringssl/0.0.0-20211025-d4f1ab9/MODULE.bazel": "6ee6353f8b1a701fe2178e1d925034294971350b6d3ac37e67e5a7d463267834",
     "https://bcr.bazel.build/modules/boringssl/0.0.0-20230215-5c22014/MODULE.bazel": "4b03dc0d04375fa0271174badcd202ed249870c8e895b26664fd7298abea7282",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
@@ -373,7 +374,7 @@
     },
     "@@rules_apple+//apple:apple.bzl%provisioning_profile_repository_extension": {
       "general": {
-        "bzlTransitiveDigest": "cfdT/RomGu+OqE9wYwPiq/kAlCblZlylK8P2/PsOMVs=",
+        "bzlTransitiveDigest": "1gIQy+6y4yPMQc1hXiKA5+XxTuwPJfW551UR/SNBYb0=",
         "usagesDigest": "vsJl8Rw5NL+5Ag2wdUDoTeRF/5klkXO8545Iy7U1Q08=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},


### PR DESCRIPTION
See https://github.com/bazel-contrib/rules_jvm_external/issues/1426:

WARNING: /home/vscode/.cache/bazel/_bazel_vscode/6f2a854b6c242f1bc1275d52318b5ceb/external/rules_jvm_external++maven+maven/BUILD:223:10: in _copy_file rule @@rules_jvm_external++maven+maven//:junit_junit_sources_4_13_2_extension: target '@@rules_jvm_external++maven+maven//:junit_junit_sources_4_13_2_extension' depends on deprecated target '@@bazel_tools//src/conditions:host_windows_x64_constraint': No longer used by Bazel and will be removed in the future. Migrate to toolchains or define your own version of this setting.

This makes that go away.