### PR TITLE
chore: Bump Nixpkgs from 25.05 to unstable, and use bazel_8 instead of bazelisk

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,16 +41,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755922037,
-        "narHash": "sha256-wY1+2JPH0ZZC4BQefoZw/k+3+DowFyfOxv17CN/idKs=",
+        "lastModified": 1758198701,
+        "narHash": "sha256-7To75JlpekfUmdkUZewnT6MoBANS0XVypW6kjUOXQwc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b1b3291469652d5a2edb0becc4ef0246fff97a7c",
+        "rev": "0147c2f1d54b30b5dd6d4a8c8542e8d7edf93b5d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Enola AI; see https://enola.dev";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
 
     nixpkgs-bun.url = "github:nixos/nixpkgs/ab1f3b61279dfe63cdc938ed90660b99e9d46619"; # bun==1.2.19
@@ -39,6 +39,10 @@
           git
           go
           jq
+          bazel_8
+          # TODO Finish switch from Bazelisk to Bazel package
+          #   by cleaning up all scripts etc. which still use
+          #   bazelisk, and then rm this, and .bazelversion
           bazelisk
           shellcheck
           nixpkgs-fmt
@@ -101,7 +105,7 @@
               echo -n "${gitRev}" >tools/version/VERSION
 
               export HOME=$TMPDIR
-              bazelisk build //java/dev/enola/cli:enola_deploy.jar
+              bazel build //java/dev/enola/cli:enola_deploy.jar
             '';
 
             installPhase = ''


### PR DESCRIPTION
This is only a 1st step; do note how both the `bazelisk` package and the `.bazelversion` have not been removed, yet.

Unfortunately they are still required, for now - because various scripts have not been cleaned-up, yet. Contributions welcome!

Relates to #1709 and (indirectly) also #1730 etc.

@dotdoom FYI