### PR TITLE
feat: Enable --http-scheme by default (re. #1646)

### DIFF
--- a/java/dev/enola/cli/CommandWithResourceProvider.java
+++ b/java/dev/enola/cli/CommandWithResourceProvider.java
@@ -45,7 +45,7 @@ public abstract class CommandWithResourceProvider implements Callable<Integer> {
             names = {"--http-scheme"},
             negatable = true,
             required = true,
-            defaultValue = "false",
+            defaultValue = "true",
             fallbackValue = "true",
             showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
             description = "Whether external HTTP requests are allowed")

--- a/java/dev/enola/common/io/resource/ResourceProvider.java
+++ b/java/dev/enola/common/io/resource/ResourceProvider.java
@@ -23,6 +23,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Optional;
 
 /**
  * Resource Provider.
@@ -34,7 +35,7 @@ import java.net.URI;
  */
 public interface ResourceProvider extends ProviderFromIRI<Resource> {
 
-    // TODO Avoid @Nullable Resource, by using the get() and optional() pattern
+    // TODO Replace @Nullable with get() and optional() pattern
     //   (as used e.g. in ChatLanguageModelProvider) and rename methods accordingly...
 
     // TODO Add (strongly typed) "metadata headers" (instead of e.g. only MediaType)
@@ -43,6 +44,15 @@ public interface ResourceProvider extends ProviderFromIRI<Resource> {
         var resource = getResource(uri);
         if (resource == null) throw new IOException("Not found: " + uri);
         return resource;
+    }
+
+    default Optional<Resource> optional(URI uri) {
+        try {
+            return Optional.ofNullable(getResource(uri));
+        } catch (Exception e) {
+            ResourceProviders.LOG.info("Exception for {}", uri, e);
+            return Optional.empty();
+        }
     }
 
     @Override

--- a/java/dev/enola/common/io/resource/ResourceProviders.java
+++ b/java/dev/enola/common/io/resource/ResourceProviders.java
@@ -29,7 +29,7 @@ import java.net.URI;
 
 public class ResourceProviders implements ResourceProvider {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ResourceProviders.class);
+    static final Logger LOG = LoggerFactory.getLogger(ResourceProviders.class);
 
     private final Iterable<ResourceProvider> resourceProviders;
 

--- a/java/dev/enola/core/EnolaServiceRegistry.java
+++ b/java/dev/enola/core/EnolaServiceRegistry.java
@@ -26,6 +26,8 @@ import dev.enola.core.thing.ListThingService;
 import dev.enola.core.thing.ThingRepositoryThingService;
 import dev.enola.core.thing.ThingService;
 import dev.enola.data.iri.template.URITemplateMatcherChain;
+import dev.enola.rdf.io.FilteringResourceIntoProtoThingConverter;
+import dev.enola.rdf.io.RdfResourceIntoProtoThingConverter;
 import dev.enola.thing.Thing;
 import dev.enola.thing.message.JavaThingToProtoThingConverter;
 import dev.enola.thing.message.ProtoThingRepository;
@@ -147,8 +149,11 @@ class EnolaServiceRegistry implements EnolaService, ProtoThingRepository {
             b.add(ListThingService.ENOLA_ROOT_LIST_IRIS, wrap(listThingService));
             b.add(ListThingService.ENOLA_ROOT_LIST_THINGS, wrap(listThingService));
             var uriTemplateMatcherChain = b.build();
-            var esr =
-                    new EnolaServiceRegistry(uriTemplateMatcherChain, new ResourceEnolaService(rp));
+            var riptc =
+                    new FilteringResourceIntoProtoThingConverter(
+                            new RdfResourceIntoProtoThingConverter(rp));
+            var res = new ResourceEnolaService(rp, riptc);
+            var esr = new EnolaServiceRegistry(uriTemplateMatcherChain, res);
             listThingService.setProtoThingProvider(esr);
             return esr;
         }

--- a/java/dev/enola/core/grpc/EnolaGrpcServerTest.java
+++ b/java/dev/enola/core/grpc/EnolaGrpcServerTest.java
@@ -30,6 +30,7 @@ import dev.enola.common.io.mediatype.MediaTypeProviders;
 import dev.enola.common.io.resource.ClasspathResource;
 import dev.enola.common.io.resource.ResourceProvider;
 import dev.enola.common.io.resource.ResourceProviders;
+import dev.enola.common.protobuf.Anys;
 import dev.enola.common.protobuf.ValidationException;
 import dev.enola.core.EnolaException;
 import dev.enola.core.EnolaService;
@@ -94,8 +95,7 @@ public class EnolaGrpcServerTest {
         var response = client.getThing(request);
         var any = response.getThing();
         // TODO Need to check if the Any is multiple Things or single Thing? Or ditch.. too complex!
-        var things = any.unpack(Things.class);
-        return things;
+        return Anys.unpack(any, Things.class);
     }
 
     private void checkGetProtoMessage(EnolaServiceBlockingStub client)

--- a/java/dev/enola/rdf/io/FilteringResourceIntoProtoThingConverter.java
+++ b/java/dev/enola/rdf/io/FilteringResourceIntoProtoThingConverter.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2025 The Enola <https://enola.dev> Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.enola.rdf.io;
+
+import dev.enola.common.convert.ConversionException;
+import dev.enola.common.io.resource.ReadableResource;
+import dev.enola.thing.proto.Thing;
+
+import java.util.List;
+import java.util.Optional;
+
+// TODO Move this interface to another package, as it's not actually RDF specific
+public class FilteringResourceIntoProtoThingConverter implements ResourceIntoProtoThingConverter {
+
+    // TODO This is an ugly temporary hack, to unblock https://github.com/enola-dev/enola/pull/1781.
+    // The better solution might be to use a proper cache? Or (or also) make RdfReaderConverterInto
+    // ignore HTML instead of RDF? It should already do that, but it clearly didn't work (well),
+    // yet. Without this, the "CI=1 ./test.bash" fails.
+
+    private final ResourceIntoProtoThingConverter delegate;
+    private final List<String> uriPrefixesToSkip;
+
+    public FilteringResourceIntoProtoThingConverter(ResourceIntoProtoThingConverter delegate) {
+        this.delegate = delegate;
+        this.uriPrefixesToSkip =
+                List.of(
+                        "https://example.org",
+                        "http://example.org",
+                        "http://www.w3.org",
+                        "https://schema.org",
+                        "https://enola.dev",
+                        "https://docs.enola.dev");
+    }
+
+    @Override
+    public Optional<List<Thing.Builder>> convert(ReadableResource input)
+            throws ConversionException {
+        var url = input.uri().toString();
+        if (uriPrefixesToSkip.stream().noneMatch(url::startsWith)) return delegate.convert(input);
+        else return Optional.empty();
+    }
+}

--- a/java/dev/enola/rdf/io/RdfResourceIntoProtoThingConverter.java
+++ b/java/dev/enola/rdf/io/RdfResourceIntoProtoThingConverter.java
@@ -17,21 +17,16 @@
  */
 package dev.enola.rdf.io;
 
-import com.google.protobuf.Message;
-
 import dev.enola.common.convert.ConversionException;
-import dev.enola.common.convert.OptionalConverter;
 import dev.enola.common.io.resource.ReadableResource;
 import dev.enola.common.io.resource.ResourceProvider;
 import dev.enola.rdf.proto.RdfProtoThingsConverter;
 import dev.enola.thing.proto.Thing;
-import dev.enola.thing.proto.Things;
 
 import java.util.List;
 import java.util.Optional;
 
-public class RdfResourceIntoProtoThingConverter
-        implements OptionalConverter<ReadableResource, List<Thing.Builder>> {
+public class RdfResourceIntoProtoThingConverter implements ResourceIntoProtoThingConverter {
 
     // TODO Also implement e.g. an MarkdownResourceIntoThingConverter
     // TODO Also implement e.g. JavaResourceIntoThingConverter
@@ -46,22 +41,6 @@ public class RdfResourceIntoProtoThingConverter
     @Override
     public Optional<List<Thing.Builder>> convert(ReadableResource from) throws ConversionException {
         var optModel = rdfReaderConverter.convert(from);
-        if (optModel.isEmpty()) return Optional.empty();
-
-        return Optional.of(rdfThingConverter.convertToList(optModel.get()));
-    }
-
-    /** This returns thingsList as Thing (if there is 1) or a {@link Things} pb. */
-    public Message.Builder asMessage(List<Thing.Builder> thingsList) {
-        Message.Builder messageBuilder;
-        if (thingsList.size() == 1) messageBuilder = thingsList.get(0);
-        else {
-            var thingsBuilder = Things.newBuilder();
-            for (var thing : thingsList) {
-                thingsBuilder.addThings(thing);
-            }
-            messageBuilder = thingsBuilder;
-        }
-        return messageBuilder;
+        return optModel.map(rdfThingConverter::convertToList);
     }
 }

--- a/java/dev/enola/rdf/io/ResourceIntoProtoThingConverter.java
+++ b/java/dev/enola/rdf/io/ResourceIntoProtoThingConverter.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2025 The Enola <https://enola.dev> Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.enola.rdf.io;
+
+import com.google.protobuf.Message;
+
+import dev.enola.common.convert.OptionalConverter;
+import dev.enola.common.io.resource.ReadableResource;
+import dev.enola.thing.proto.Thing;
+import dev.enola.thing.proto.Things;
+
+import java.util.List;
+
+// TODO Move this interface to another package, as it's not actually RDF specific
+public interface ResourceIntoProtoThingConverter
+        extends OptionalConverter<ReadableResource, List<Thing.Builder>> {
+
+    /** This returns thingsList as Thing (if there is 1) or a {@link Things} pb. */
+    default Message.Builder asMessage(List<Thing.Builder> thingsList) {
+        Message.Builder messageBuilder;
+        if (thingsList.size() == 1) messageBuilder = thingsList.get(0);
+        else {
+            var thingsBuilder = Things.newBuilder();
+            for (var thing : thingsList) {
+                thingsBuilder.addThings(thing);
+            }
+            messageBuilder = thingsBuilder;
+        }
+        return messageBuilder;
+    }
+}


### PR DESCRIPTION
Relates to https://github.com/enola-dev/enola/issues/1646, and https://github.com/enola-dev/enola/pull/1754

Factored out from #1778, because this is a PITA.

--- 

This makes the instructions for the "enola ai --agents=..." on https://docs.enola.dev/agents a bit shorter and simpler.

It required hacking something in the old Thing Resource code, but this probably for the better now like it's done here.