### PR TITLE
Switch remotejdk_21 to local JDK even for compilation, not just runtime

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,6 +10,7 @@ common --tool_java_language_version=21
 # https://bazel.build/docs/user-manual#java_runtime_version
 common --java_runtime_version=local_jdk_21
 common --tool_java_runtime_version=local_jdk_21
+common --action_env=JAVA_HOME
 
 # https://github.com/bazelbuild/intellij/issues/1169
 common --incompatible_strict_action_env

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -27,6 +27,10 @@ GRPC_JAVA_VERSION = "1.75.0"
 # https://registry.bazel.build/modules/rules_java
 bazel_dep(name = "rules_java", version = "8.16.1")
 
+# see ./tools/java_toolchain/BUILD
+# see https://github.com/bazelbuild/bazel/issues/20877, NB the "_definition" suffix!
+register_toolchains("//tools/java_toolchain:repository_default_java_toolchain_definition")
+
 # https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/bzlmod.md
 bazel_dep(name = "rules_go", version = "0.57.0")
 bazel_dep(name = "gazelle", version = "0.45.0")

--- a/tools/java_toolchain/BUILD
+++ b/tools/java_toolchain/BUILD
@@ -1,0 +1,29 @@
+# https://github.com/enola-dev/enola/issues/1806
+
+load(
+    "@bazel_tools//tools/jdk:default_java_toolchain.bzl",
+    "DEFAULT_TOOLCHAIN_CONFIGURATION",
+    "default_java_toolchain",
+)
+#load("@rules_java//java/toolchains:java_runtime.bzl", "java_runtime")
+
+#java_runtime(
+#    name = "jdk_runtime",
+#    # TODO Replace hard-coded /nix/store path with JAVA_HOME; using 'common --action_env=JAVA_HOME' in .bazelrc?
+#    java_home = "/nix/store/hm028d05qs6138ggq02239sh6qf5xwd6-openjdk-21.0.8+9/lib/openjdk",
+#    visibility = ["//visibility:public"],
+#)
+
+default_java_toolchain(
+    name = "repository_default_java_toolchain",
+    configuration = DEFAULT_TOOLCHAIN_CONFIGURATION,
+
+    # INSTEAD of: java_runtime = "@rules_java//toolchains:remotejdk_21",
+    # OR above's: java_runtime = ":jdk_runtime",
+    java_runtime = "@bazel_tools//tools/jdk:current_host_java_runtime",
+
+    # Do *NOT* add "--enable-preview" javacopts + jvm_opts here!!
+    # (See https://github.com/enola-dev/enola/issues/511 for why not.)
+    source_version = "21",
+    target_version = "21",
+)


### PR DESCRIPTION
Fixes #1806.

But does still not fix #1730.

PS: Includes (not directly related) #1807.