### PR TITLE
fix: Using 'require_serial: true' for JavaDoc pre-commit reduces 40s to 18s!

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -220,3 +220,4 @@ repos:
         language: script
         entry: tools/javadoc/pre-commit.bash
         files: ^java/.*\.java$
+        require_serial: true


### PR DESCRIPTION
See https://pre-commit.com/#creating-new-hooks.