### PR TITLE
chore: Test 'bazel vendor' Nix outputHash stability (re. #1875)

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -4,6 +4,7 @@ site
 
 .be
 .bazelbsp
+.built
 .cache
 .direnv
 .eclipse

--- a/.gitignore
+++ b/.gitignore
@@ -45,14 +45,13 @@ web/web-out/
 # Maven
 java/.mvn/wrapper/maven-wrapper.jar
 java/target
-.built/.m2
 
 # https://jbang.dev
 .jbang/
 
 tools/version/VERSION
 
-# LinkML
+# Miscellaneous generated/output varia (incl. LinkML, .m2, HOME, VENDOR, etc.)
 .built
 
 # https://github.com/VirtusLab/bazel-steward/issues/424


### PR DESCRIPTION
This is a sub-set of #1873,

which we could try to get into a mergeable state sooner rather than later, 

because it would allow to observe #1875 in practive - letting us see if `vendor` output is stable enough to e.g. run on GitHub Actions environment.

This PR currently fails for me locally due to `Permission denied` #1876; I'm curious to see if it passes on CI.

@dotdoom shout if you know how to fix that (permission) for this PR? Then I would merge this, and we could see how stable it really is.