### PR TITLE
ai: Make Gemini CLI use AGENTS.md, with a GEMINI.md "redirect"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,7 @@ repos:
         files: \.(md|html)$
         # docs/specs/**.md is starting to use YAML Frontmatter, and can't have license headers
         # due to the https://github.com/markdownlint/markdownlint/issues/515 limitation... :=()
-        exclude: ^.github/|.gemini/|test/|docs/blog/posts/|docs/use/execmd/demo.md|docs/specs/|docs/agents
+        exclude: ^.github/|.gemini/|test/|docs/blog/posts/|docs/use/execmd/demo.md|docs/specs/|docs/agents|GEMINI.md
         args:
           - --comment-style
           - "<!--|   |-->"

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,3 @@
+# Gemini
+
+@./AGENTS.md


### PR DESCRIPTION
According to https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/gemini-md.md#customize-the-context-file-name, I should also have been able to do this in my https://github.com/vorburger/vorburger-dotfiles-bin-etc/blob/main/dotfiles/.gemini/settings.json, but for some reason that doesn't work (for me).

Also by doing it like this it will work for other users as well - so that's probably better anyways.

@dotdoom FYI