### PR TITLE
Fix: `./enola` launch script must rebuild when `MODULE.bazel` etc. etc. change (not just `java/`)

### DIFF
--- a/MODULE.update.bash
+++ b/MODULE.update.bash
@@ -17,6 +17,8 @@
 
 set -euo pipefail
 
+ROOT="$(dirname "$(realpath "$0")")"
+
 bazel run //java/dev/enola/common/template/tool:temply -- \
     "$PWD"/MODULE.bom.handlebars.yaml "$PWD"/MODULE.bazel.handlebars >MODULE.bazel.new
 
@@ -25,5 +27,8 @@ mv MODULE.bazel.new MODULE.bazel
 REPIN=1 bazel run @maven//:pin
 
 tools/javac/classpath.bash
+
+# https://github.com/enola-dev/enola/issues/1901
+rm -f "$ROOT"/.cache/java.hash "$ROOT"/.cache/java.hash.previous
 
 ./test.bash

--- a/enola
+++ b/enola
@@ -26,7 +26,15 @@ ROOT="$(dirname "$(realpath "$0")")"
 if [ -x "$(command -v hashdir)" ]; then
   mkdir -p "$ROOT"/.cache
   mv "$ROOT"/.cache/java.hash "$ROOT"/.cache/java.hash.previous 2>/dev/null || true
-  hashdir --quiet "$ROOT"/java/ > "$ROOT"/.cache/java.hash
+  # TODO Replace (Python) hashdir with my own (Java) tool, see https://docs.enola.dev/use/info/#digest
+  {
+    hashdir --quiet "$ROOT"/java/
+    # https://github.com/enola-dev/enola/issues/1901
+    hashdir --quiet "$ROOT"/generated/protoc/java
+    hashdir --quiet "$ROOT"/models/
+    hashdir --quiet "$ROOT"/web/
+    sha512sum "$ROOT/MODULE.bazel"
+  } >"$ROOT"/.cache/java.hash
   set +e
   diff "$ROOT"/.cache/java.hash "$ROOT"/.cache/java.hash.previous >/dev/null 2>/dev/null
   DIFF="$?"
@@ -38,6 +46,7 @@ fi
 LOG=$(mktemp)
 if [ "$DIFF" -ne 0 ] || [ ! -f "$ROOT"/site/download/latest/enola.jar ]; then
   set +e
+  echo "Input hash changed, re-building enola.jar..."
   "$ROOT"/tools/distro/build-execjar.bash >"$LOG" 2>&1
   exit_code="$?"
   set -e


### PR DESCRIPTION
Fixes #1901.