### PR TITLE
fix: Broken MCP works again (fixes #1862)

### DIFF
--- a/java/dev/enola/ai/mcp/McpLoader.java
+++ b/java/dev/enola/ai/mcp/McpLoader.java
@@ -31,7 +31,6 @@ import dev.enola.common.Version;
 import dev.enola.common.io.object.ObjectReader;
 import dev.enola.common.io.object.jackson.JacksonObjectReaderWriterChain;
 import dev.enola.common.io.resource.ReadableResource;
-import dev.enola.common.jackson.ObjectMappers;
 import dev.enola.common.name.NamedTypedObjectProvider;
 import dev.enola.common.secret.SecretManager;
 
@@ -41,7 +40,7 @@ import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
 import io.modelcontextprotocol.client.transport.ServerParameters;
 import io.modelcontextprotocol.client.transport.StdioClientTransport;
-import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 
@@ -131,6 +130,11 @@ public class McpLoader implements NamedTypedObjectProvider<McpSyncClient> {
         }
     }
 
+    // TODO Make mcpJsonMapper() private instead of public when CallToolCommand doesn't need it
+    public McpJsonMapper mcpJsonMapper() {
+        return McpJsonMapper.getDefault();
+    }
+
     @VisibleForTesting
     McpServerConnectionsConfig.ServerConnection replaceSecretPlaceholders(
             McpServerConnectionsConfig.ServerConnection originalServerConnection)
@@ -150,9 +154,7 @@ public class McpLoader implements NamedTypedObjectProvider<McpSyncClient> {
         switch (connectionConfig.type) {
             case stdio -> {
                 var params = createStdIoServerParameters(connectionConfig);
-                var transport =
-                        new StdioClientTransport(
-                                params, new JacksonMcpJsonMapper(ObjectMappers.INSTANCE));
+                var transport = new StdioClientTransport(params, mcpJsonMapper());
                 transport.setStdErrorHandler(new McpServerStdErrLogConsumer(origin));
                 return transport;
             }

--- a/java/dev/enola/ai/mcp/cli/CallToolCommand.java
+++ b/java/dev/enola/ai/mcp/cli/CallToolCommand.java
@@ -25,10 +25,8 @@ import dev.enola.common.io.resource.ClasspathResource;
 import dev.enola.common.io.resource.FileResource;
 import dev.enola.common.io.resource.ResourceProvider;
 import dev.enola.common.io.resource.ResourceProviders;
-import dev.enola.common.jackson.ObjectMappers;
 import dev.enola.common.secret.auto.AutoSecretManager;
 
-import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 
 import org.jspecify.annotations.Nullable;
@@ -77,8 +75,7 @@ public class CallToolCommand implements Callable<Integer> {
         var callToolRequest =
                 CallToolRequest.builder()
                         .name(tool)
-                        .arguments(
-                                new JacksonMcpJsonMapper(ObjectMappers.INSTANCE), argumentsAsJson)
+                        .arguments(loader.mcpJsonMapper(), argumentsAsJson)
                         .build();
         var callToolResult = toolClient.callTool(callToolRequest);
         for (var content : callToolResult.content()) {


### PR DESCRIPTION
Fixes #1862.

See also https://github.com/modelcontextprotocol/java-sdk/issues/605.