### PR TITLE
docs: Enable mcp list-tools demo on use/mcp

### DIFF
--- a/docs/use/mcp/index.md
+++ b/docs/use/mcp/index.md
@@ -31,15 +31,13 @@ $ ./enola -v mcp call-tool modelcontextprotocol/everything echo '{"message":"hi"
 
 ## List MCP Tools
 
-```bash $% cd ../.././..
-$ ./enola mcp list-tools --help
-...
-```
-
-<!-- TODO Why does this not work?! Is it just because secrets are missing on CI? See also test-cli.bash ...
-
 ```bash cd ../.././..
-$ ./enola -vv mcp list-tools
+$ ./enola mcp list-tools
 ...
 ```
---->
+
+## Screencast
+
+![Demo](script.svg)
+
+<!-- PS: This is also exercised in the test-cli.bash script. -->

--- a/docs/use/mcp/script.svg
+++ b/docs/use/mcp/script.svg
@@ -1,0 +1,1 @@
+<!-- This SVG will be generated during the build by tools/docs/build.bash -->


### PR DESCRIPTION
Relates to recent fixes, which made that this now works.

https://docs.enola.dev/use/mcp will be updated when this is deployed.
