### PR TITLE
chore: set -x in tools/javac/classpath.bash

### DIFF
--- a/tools/javac/classpath.bash
+++ b/tools/javac/classpath.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright 2023-2025 The Enola <https://enola.dev> Authors
+# Copyright 2023-2026 The Enola <https://enola.dev> Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -euo pipefail
+# Use -x because this script sometimes strangely fails on CI...
+set -xeuo pipefail
+
+echo "tools/javac/classpath.bash now running..."
 
 tools/javac/dependencies.bash
 


### PR DESCRIPTION
Relates to https://github.com/enola-dev/enola/actions/runs/20658396982/job/59315697169 build failure.